### PR TITLE
[Resources] Use Python 3.7 type hints in `BasicAssetLibrary`

### DIFF
--- a/plugin/BasicAssetLibrary/bal.py
+++ b/plugin/BasicAssetLibrary/bal.py
@@ -27,6 +27,7 @@ engineering practice".
 import json
 
 from collections import namedtuple
+from typing import Set
 from urllib.parse import urlparse
 
 EntityInfo = namedtuple("EntityInfo", ("name"), defaults=("",))
@@ -100,7 +101,7 @@ def entity(entity_info: EntityInfo, library: dict) -> Entity:
     return Entity(**entity_dict["versions"][-1])
 
 
-def management_policy(trait_set: set[str], access: str, library: dict) -> dict:
+def management_policy(trait_set: Set[str], access: str, library: dict) -> dict:
     """
     Retrieves the management policy for the supplied trait set. The
     default will be used unless an alternate default or trait set


### PR DESCRIPTION
Part of https://github.com/OpenAssetIO/OpenAssetIO/issues/660, reverts to using Python 3.7 style type hints, so we can maintain broader compatibility.

NB: This is demonstrated working in https://github.com/OpenAssetIO/OpenAssetIO/pull/694, we'll be shortly adding test CI test coverage to this repo. Wanted to make sure this parallel work didn't get lost.