### PR TITLE
Add `pylint` and `black` CI checks

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,44 @@
+name: Code quality
+on: pull_request
+
+jobs:
+  pylint:
+    runs-on: ubuntu-latest
+    name: Pylint
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -r tests/requirements.txt
+
+      - name: Lint
+        uses: TheFoundryVisionmongers/fn-pylint-action@v1.1
+        with:
+          pylint-disable: fixme  # We track 'todo's through other means
+          pylint-rcfile: "./pyproject.toml"
+          pylint-paths: "plugin tests"
+
+  black:
+    runs-on: ubuntu-latest
+    name: Python formatting
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        run: |
+          python -m pip install black
+
+      - name: Check Python formatting
+        run: black --check .
+

--- a/plugin/BasicAssetLibrary/BasicAssetLibraryInterface.py
+++ b/plugin/BasicAssetLibrary/BasicAssetLibraryInterface.py
@@ -13,6 +13,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 #
+
+# Fix module-level name check, as well as OpenAssetIO methods
+# pylint: disable=invalid-name
 """
 A single-class module, providing the BasicAssetLibraryInterface class.
 """
@@ -36,7 +39,7 @@ __all__ = [
 # pylint: disable=abstract-method
 # Methods in C++ end up with "missing docstring"
 # pylint: disable=missing-docstring
-# pylint: disable=no-self-use, too-many-arguments, invalid-name
+# pylint: disable=too-many-arguments, unused-argument
 
 
 class BasicAssetLibraryInterface(ManagerInterface):
@@ -64,11 +67,9 @@ class BasicAssetLibraryInterface(ManagerInterface):
         return {constants.kField_EntityReferencesMatchPrefix: self.__reference_prefix}
 
     def settings(self, hostSession):
-        # pylint: disable=unused-argument
         return self.__settings.copy()
 
     def initialize(self, managerSettings, hostSession):
-        # pylint: disable=unused-argument
         bal.validate_settings(managerSettings)
         self.__settings.update(managerSettings)
 
@@ -99,7 +100,6 @@ class BasicAssetLibraryInterface(ManagerInterface):
         ]
 
     def isEntityReferenceString(self, someString, hostSession):
-        # pylint: disable=unused-argument
         return someString.startswith(self.__reference_prefix)
 
     def entityExists(self, entityRefs, context, hostSession):

--- a/plugin/BasicAssetLibrary/__init__.py
+++ b/plugin/BasicAssetLibrary/__init__.py
@@ -43,7 +43,7 @@ need to be on `$PYTHONPATH` directly, the plugin system takes care
 of extending Python's runtime paths accordingly.
 """
 
-# pylint: disable=import-outside-toplevel
+# pylint: disable=import-outside-toplevel, invalid-name
 #
 # It is important to minimise imports here. This module will be loaded
 # when the plugin system scans for plugins. Postpone importing any
@@ -73,6 +73,4 @@ class BasicAssetLibraryPlugin(PythonPluginSystemManagerPlugin):
 # Set the plugin class as the public entrypoint for the plugin system.
 # A plugin is only considered if it exposes a `plugin` variable at this
 # level, holding a class derived from PythonPluginSystemManagerPlugin.
-
-# pylint: disable=invalid-name
 plugin = BasicAssetLibraryPlugin

--- a/plugin/BasicAssetLibrary/bal.py
+++ b/plugin/BasicAssetLibrary/bal.py
@@ -168,8 +168,14 @@ def _library_entity_dict(entity_info: EntityInfo, library: dict):
 
 
 class UnknownBALEntity(Exception):
-    pass
+    """
+    An exception raised for a reference to a non-existent entity in the
+    library.
+    """
 
 
 class MalformedBALReference(Exception):
-    pass
+    """
+    An exception raised for a reference that is missing an entity name
+    or other required part.
+    """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,6 @@
 Shared fixtures for BasicAssetLibrary pytest coverage.
 """
 
-# pylint: disable=no-self-use
 # pylint: disable=invalid-name,redefined-outer-name
 # pylint: disable=missing-class-docstring,missing-function-docstring
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -94,7 +94,7 @@ fixtures = {
             ),
             "a_malformed_reference": MALFORMED_REF,
             "the_error_string_for_a_malformed_reference": (
-                f"Missing entity name in path component"
+                "Missing entity name in path component"
             ),
         }
     },
@@ -103,7 +103,7 @@ fixtures = {
             "a_reference_to_a_writable_entity": "bal:///someNewEntity",
             "a_set_of_valid_traits": some_registerable_traitset,
             "the_error_string_for_a_malformed_reference": (
-                f"Missing entity name in path component"
+                "Missing entity name in path component"
             ),
         }
     },
@@ -112,7 +112,7 @@ fixtures = {
             "a_reference_to_a_writable_entity": "bal:///someNewEntity",
             "a_traitsdata_for_a_reference_to_a_writable_entity": some_registerable_traitsdata,
             "the_error_string_for_a_malformed_reference": (
-                f"Missing entity name in path component"
+                "Missing entity name in path component"
             ),
         }
     },

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -39,11 +39,11 @@ with open(test_library_path, "r", encoding="utf-8") as file:
 # Constants
 #
 
-identifier = "org.openassetio.examples.manager.bal"
+IDENTIFIER = "org.openassetio.examples.manager.bal"
 
-valid_ref = "bal:///references/can/contain/🐠"
-non_ref = "not a Ŕeference"
-malformed_ref = "bal:///"
+VALID_REF = "bal:///references/can/contain/🐠"
+NON_REF = "not a Ŕeference"
+MALFORMED_REF = "bal:///"
 
 an_existing_entity_name = next(iter(test_library["entities"].keys()))
 
@@ -53,14 +53,14 @@ some_registerable_traitsdata.setTraitProperty("trait1", "some", "stringValue")
 some_registerable_traitsdata.setTraitProperty("trait2", "count", 4)
 
 fixtures = {
-    "identifier": identifier,
+    "identifier": IDENTIFIER,
     "settings": {"library_path": test_library_path},
     "shared": {
-        "a_valid_reference": valid_ref,
-        "an_invalid_reference": non_ref,
-        "a_malformed_reference": malformed_ref,
+        "a_valid_reference": VALID_REF,
+        "an_invalid_reference": NON_REF,
+        "a_malformed_reference": MALFORMED_REF,
     },
-    "Test_identifier": {"test_matches_fixture": {"identifier": identifier}},
+    "Test_identifier": {"test_matches_fixture": {"identifier": IDENTIFIER}},
     "Test_displayName": {"test_matches_fixture": {"display_name": "Basic Asset Library 📖"}},
     "Test_info": {
         "test_matches_fixture": {"info": {kField_EntityReferencesMatchPrefix: "bal:///"}}
@@ -79,7 +79,7 @@ fixtures = {
     "Test_entityExists": {
         "shared": {
             "a_reference_to_an_existing_entity": f"bal:///{an_existing_entity_name}",
-            "a_reference_to_a_nonexisting_entity": valid_ref,
+            "a_reference_to_a_nonexisting_entity": VALID_REF,
         }
     },
     "Test_resolve": {
@@ -92,7 +92,7 @@ fixtures = {
             "the_error_string_for_a_reference_to_a_missing_entity": (
                 "Entity 'bal:///missing_entity' not found"
             ),
-            "a_malformed_reference": malformed_ref,
+            "a_malformed_reference": MALFORMED_REF,
             "the_error_string_for_a_malformed_reference": (
                 f"Missing entity name in path component"
             ),

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,4 @@
+black
 openassetio
+pylint==2.15.5  # Guard against warn/error changes
 pytest

--- a/tests/test_bal.py
+++ b/tests/test_bal.py
@@ -34,7 +34,6 @@ $OPENASSETIO_PLUGIN_PATH:
 import os
 import pytest
 
-# pylint: disable=no-self-use
 # pylint: disable=invalid-name,redefined-outer-name
 # pylint: disable=missing-class-docstring,missing-function-docstring
 


### PR DESCRIPTION
For pure python code, outside the main API, we use PEP8 with an extended line length of 99 + black formatting.