### PR TITLE
Publish BAL to PyPI

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The Foundry Visionmongers Ltd#
+
+name: Build Wheels
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  pull_request:
+
+concurrency:
+  # Shared with `deploy-pypi`.
+  group: wheel-${{ github.ref }}
+  # Cancel any in-progress build or publish.
+  cancel-in-progress: true
+
+jobs:
+  build_wheels:
+    name: Build wheel
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel
+
+      - name: Build wheels
+        run: pip wheel --no-deps --wheel-dir wheelhouse .
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: openassetio-manager-bal-wheels
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The Foundry Visionmongers Ltd
+
+name: Deploy PyPI
+
+concurrency:
+  # Shared with `build-wheels`.
+  group: wheel-${{ github.ref }}
+  # Allow `build-wheels` to finish.
+  cancel-in-progress: false
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish_testpypi:
+    name: Publish distribution 📦 to TestPyPI
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Download wheels from commit ${{ github.sha }}
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build-wheels.yml
+          workflow_conclusion: success
+          commit: ${{ github.sha }}
+          name: openassetio-manager-bal-wheels
+          path: dist
+
+      - name: Upload to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_ACCESS_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+
+  publish_pypi:
+    name: Publish distribution 📦 to PyPI
+    needs: publish_testpypi
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Download wheels from commit ${{ github.sha }}
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build-wheels.yml
+          workflow_conclusion: success
+          commit: ${{ github.sha }}
+          name: openassetio-manager-bal-wheels
+          path: dist
+
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_ACCESS_TOKEN }}

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 Release Notes
 =============
 
-v1.0.0-alpha.x
+v1.0.0-alpha.2
 --------------
 
 ### Breaking changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
 readme = "README.md"
 
 [project.urls]
+OpenAssetIO = "https://github.com/OpenAssetIO/OpenAssetIO"
 Source = "https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL"
 Issues = "https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues"
 


### PR DESCRIPTION
Adopts the established pattern from other repos. A Test PyPI release is available here:

  https://test.pypi.org/project/openassetio-manager-bal ([CI here](https://github.com/foundrytom/OpenAssetIO-Manager-BAL/actions/runs/3629498213)).

Closes #10