### PR TITLE
Add support for `getRelatedReferences`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,8 +13,8 @@ v1.0.0-alpha.x
 
 ## Improvements
 
-- Improved error messaging for missing entities - they now also contain
-  the missing entity's name.
+- Improved error messaging for missing entities and malformed entity
+  references - it now contains the relevant string to aid debugging.
 
 
 v1.0.0-alpha.3

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,15 @@
 Release Notes
 =============
 
+v1.0.0-alpha.x
+--------------
+
+## Improvements
+
+- Improved error messaging for missing entities - they now also contain
+  the missing entity's name.
+
+
 v1.0.0-alpha.3
 --------------
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,13 @@ Release Notes
 v1.0.0-alpha.x
 --------------
 
+### New features
+
+- Added support for `getRelatedReferences` queries against a BAL
+  library. See `schema.json` for library syntax, there is an additional
+  example in the function's [test library](./tests/resources/library_business_logic_suite_related_references.json).
+  [#17](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/17)
+
 ## Improvements
 
 - Improved error messaging for missing entities - they now also contain

--- a/plugin/openassetio_manager_bal/bal.py
+++ b/plugin/openassetio_manager_bal/bal.py
@@ -77,7 +77,7 @@ def parse_entity_ref(entity_ref: str) -> EntityInfo:
     uri_parts = urlparse(entity_ref)
 
     if len(uri_parts.path) <= 1:
-        raise MalformedBALReference("Missing entity name in path component")
+        raise MalformedBALReference("Missing entity name in path component", entity_ref)
 
     # path will start with a /
     name = uri_parts.path[1:]
@@ -250,3 +250,6 @@ class MalformedBALReference(RuntimeError):
     An exception raised for a reference that is missing an entity name
     or other required part.
     """
+
+    def __init__(self, message, reference: str):
+        super().__init__(f"Malformed BAL reference: {message} '{reference}'")

--- a/plugin/openassetio_manager_bal/bal.py
+++ b/plugin/openassetio_manager_bal/bal.py
@@ -97,7 +97,7 @@ def entity(entity_info: EntityInfo, library: dict) -> Entity:
     """
     entity_dict = _library_entity_dict(entity_info, library)
     if entity_dict is None:
-        raise UnknownBALEntity()
+        raise UnknownBALEntity(entity_info)
 
     return Entity(**entity_dict["versions"][-1])
 
@@ -174,6 +174,9 @@ class UnknownBALEntity(RuntimeError):
     An exception raised for a reference to a non-existent entity in the
     library.
     """
+
+    def __init__(self, entity_info: EntityInfo):
+        super().__init__(f"Unknown BAL entity: '{entity_info.name}'")
 
 
 class MalformedBALReference(RuntimeError):

--- a/plugin/openassetio_manager_bal/bal.py
+++ b/plugin/openassetio_manager_bal/bal.py
@@ -169,14 +169,14 @@ def _library_entity_dict(entity_info: EntityInfo, library: dict):
     return entities_dict.get(entity_info.name)
 
 
-class UnknownBALEntity(Exception):
+class UnknownBALEntity(RuntimeError):
     """
     An exception raised for a reference to a non-existent entity in the
     library.
     """
 
 
-class MalformedBALReference(Exception):
+class MalformedBALReference(RuntimeError):
     """
     An exception raised for a reference that is missing an entity name
     or other required part.

--- a/schema.json
+++ b/schema.json
@@ -177,6 +177,42 @@
                 "required": ["traits"],
                 "additionalProperties": false
               }
+            },
+            "relations": {
+              "type": "array",
+              "description": "Descriptions of entity relationships. These combine a description of the nature of the relationship - using traits, and a list of related entities.",
+              "items": {
+                "type": "object",
+                "description": "The definition of a particular relationship",
+                "properties": {
+                  "traits": {
+                    "description": "Traits and their associated properties that describe the nature of the relationship itself (not the related entities).",
+                    "type": "object",
+                    "patternProperties": {
+                      ".*": {
+                        "description": "The trait's property values.",
+                        "type": "object",
+                        "patternProperties": {
+                          ".*": {
+                            "type": ["string", "number", "boolean"]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "entities": {
+                    "type": "array",
+                    "description": "The entities that are referenced by this relationship.",
+                    "minItems": 1,
+                    "items": {
+                      "description": "The name of the BAL entity as it appears in the top-level 'entities' object.",
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": ["traits", "entities"],
+                "additionalProperties": false
+              }
             }
           },
           "required": ["versions"],

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -94,7 +94,7 @@ fixtures = {
             ),
             "a_malformed_reference": MALFORMED_REF,
             "the_error_string_for_a_malformed_reference": (
-                "Missing entity name in path component"
+                "Malformed BAL reference: Missing entity name in path component 'bal:///'"
             ),
         }
     },
@@ -103,7 +103,7 @@ fixtures = {
             "a_reference_to_a_writable_entity": "bal:///someNewEntity",
             "a_set_of_valid_traits": some_registerable_traitset,
             "the_error_string_for_a_malformed_reference": (
-                "Missing entity name in path component"
+                "Malformed BAL reference: Missing entity name in path component 'bal:///'"
             ),
         }
     },
@@ -112,7 +112,7 @@ fixtures = {
             "a_reference_to_a_writable_entity": "bal:///someNewEntity",
             "a_traitsdata_for_a_reference_to_a_writable_entity": some_registerable_traitsdata,
             "the_error_string_for_a_malformed_reference": (
-                "Missing entity name in path component"
+                "Malformed BAL reference: Missing entity name in path component 'bal:///'"
             ),
         }
     },

--- a/tests/resources/library_business_logic_suite_related_references.json
+++ b/tests/resources/library_business_logic_suite_related_references.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenAssetIO/OpenAssetIO/main/resources/examples/manager/BasicAssetLibrary/schema.json",
+  "entities": {
+    "entity/original": {
+      "versions": [{"traits": {}}],
+      "relations": [
+        {
+          "traits": {"proxy": {}},
+          "entities": ["entity/proxy/1", "entity/proxy/2"]
+        },
+        {
+          "traits": {"proxy": {"type": "alt"}},
+          "entities": ["entity/proxy/3"]
+        },
+        {
+          "traits": {"source": {}},
+          "entities": ["entity/source"]
+        },
+        {
+          "traits": {"missing": {}},
+          "entities": ["missingEntity"]
+        }
+      ]
+    },
+    "entity/proxy/1": {
+      "versions": [{"traits": {"a": {}}}]
+    },
+    "entity/proxy/2": {
+      "versions": [{"traits": {"a": {}, "b": {}}}]
+    },
+    "entity/proxy/3": {
+      "versions": [{"traits": {"b": {}}}]
+    },
+    "entity/source": {
+      "versions": [{"traits": {}}],
+      "relations": [
+        {
+          "traits": {"derived": {}},
+          "entities": ["entity/original"]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Extends the BAL library to allow arbitrary relationships to be defined between entities. Relationships are un-versioned, and exist at the entity level to simplify understanding (and implementation).

Closes https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/17.