### PR TITLE
[Build] Support Poetry

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,15 @@
 Release Notes
 =============
 
+v1.0.0-alpha.x
+--------------
+
+### Improvements
+
+- Adds entry point support for Poetry based builds.
+  [#16](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/16)
+
+
 v1.0.0-alpha.3
 --------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ Issues = "https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues"
 # allow entry point based discovery.
 [project.entry-points."openassetio.manager_plugin"]
 plugin_package_or_module = "openassetio_manager_bal"
+# Poetry's alternate declaration of an entry point
+[tool.poetry.plugins."openassetio.manager_plugin"]
+plugin_package_or_module = "openassetio_manager_bal"
 
 [build-system]
 requires = [


### PR DESCRIPTION
Poetry uses an alternate entry in `pyproject.toml` to declare entry points.

Closes #16.