### PR TITLE
[Release] Bump version to `v1.0.0-alpha.4`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,6 +16,8 @@ v1.0.0-alpha.x
 - Improved error messaging for missing entities and malformed entity
   references - it now contains the relevant string to aid debugging.
 
+- Bumped OpenAssetIO version to `v1.0.0a8`.
+
 
 v1.0.0-alpha.3
 --------------

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 Release Notes
 =============
 
-v1.0.0-alpha.x
+v1.0.0-alpha.4
 --------------
 
 ### New features
@@ -11,7 +11,7 @@ v1.0.0-alpha.x
   example in the function's [test library](./tests/resources/library_business_logic_suite_related_references.json).
   [#17](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/17)
 
-## Improvements
+### Improvements
 
 - Improved error messaging for missing entities and malformed entity
   references - it now contains the relevant string to aid debugging.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "openassetio-manager-bal"
-version = "1.0.0a3"
+version = "1.0.0a4"
 requires-python = ">=3.7"
 dependencies = [
     "openassetio == 1.0.0a8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ name = "openassetio-manager-bal"
 version = "1.0.0a3"
 requires-python = ">=3.7"
 dependencies = [
-    "openassetio == 1.0.0a7"
+    "openassetio == 1.0.0a8"
 ]
 
 authors = [


### PR DESCRIPTION
Takes the opportunity to bump OpenAssetIO version to alpha.8 too.