### PR TITLE
Add variable expansion to string trait property values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ manager behavior.
 - Resolves references with the `bal:///` prefix to data from a
   pre-configured library of assets stored in a `.json` file.
 
+- Environment variables are expanded in string-type trait property
+  values (using the `$var` or `${var}` syntax, escape `$` using `$$`). A
+  library can also define arbitrary variables of its own under the
+  top-level `variables` key. In addition, BAL provides the built-in
+  `$bal_library_path` and `$bal_library_dir` variables, which can be
+  used to anchor to the current library location.
+
 - The library file to be used is controlled by the `library_path`
   setting, and this should point to a library file with valid content.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,24 @@
 Release Notes
 =============
 
+v1.0.0-alpha.x
+--------------
+
+### New features
+
+- Variables are now expanded in any string properties of an entity's
+  traits. Expansion occurs during resolve to allow for variation in the
+  environment between calls. Note: Only the `$var` and `${var}` syntax
+  is supported. You can escape a literal `$` using `$$`. In addition to
+  the environment, a library can define arbtirary variables under the
+  top level `variables` key. BAL also provides several implicit
+  variables of its own:
+  - `bal_library_path` The absolute path to the current library.
+  - `bal_library_dir` The absolute path to the directory containing the
+     current library.
+  [#22](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/22)
+
+
 v1.0.0-alpha.4
 --------------
 

--- a/schema.json
+++ b/schema.json
@@ -5,6 +5,18 @@
   "description": "The data store that backs an instance of the BAL manager",
   "type": "object",
   "properties": {
+    "variables": {
+      "description": "Arbitrary variables to be substituted in string trait properties",
+      "type": "object",
+      "patternProperties": {
+        "[a-zA-Z_]+": {
+          "description": "The value to substitute",
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false
+    },
     "managementPolicy": {
       "description": "Custom managementPolicy responses",
       "type": "object",

--- a/tests/resources/library_business_logic_suite_var_expansion.json
+++ b/tests/resources/library_business_logic_suite_var_expansion.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://raw.githubusercontent.com/OpenAssetIO/OpenAssetIO/main/resources/examples/manager/BasicAssetLibrary/schema.json",
+  "variables": {
+    "aLibraryVar": "defined in the JSON"
+  },
+  "entities": {
+    "entity": {
+      "versions": [
+        {
+          "traits": {
+            "aTrait": {
+              "none": "No vars in string",
+              "HOME": "$HOME",
+              "UserProfile": "$UserProfile",
+              "CUSTOM": "String with ${CUSTOM} var",
+              "MISSING": "A $MISSING var",
+              "anInt": 3,
+              "aBool": true,
+              "bal_library_dir": "Library is in $bal_library_dir",
+              "bal_library_path": "Library is ${bal_library_path}",
+              "aLibraryVar": "Value $aLibraryVar"
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Closes #22.

I didn't use `os.path.expandvars` in the end, for the noted reasons. Took the liberty of adding the lib path/dir implicit vars conceived after the initial chat too.