### PR TITLE
Update to `getWithRelationship[s]`

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -29,11 +29,23 @@ jobs:
         with:
           python-version: "3.9"
 
+      - name: Download wheels from commit OpenAssetIO feature branch
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build-wheels.yml
+          workflow_conclusion: success
+          name: openassetio-wheels
+          repo: OpenAssetIO/OpenAssetIO
+          branch: feature/relatedReferencesRefactor
+          path: deps
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install setuptools wheel
-          python -m pip install -r requirements.txt
+          # Use wheels from feature branch for intermediate testing
+          python -m pip install ./deps/openassetio-*cp39*-manylinux_*_x86_64.whl
+          # python -m pip install -r requirements.txt
 
       - name: Build wheels
         run: pip wheel --no-deps --wheel-dir wheelhouse .

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -13,9 +13,21 @@ jobs:
         with:
           python-version: 3.9
 
+      - name: Download wheels from commit OpenAssetIO feature branch
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build-wheels.yml
+          workflow_conclusion: success
+          name: openassetio-wheels
+          repo: OpenAssetIO/OpenAssetIO
+          branch: feature/relatedReferencesRefactor
+          path: deps
+
       - name: Install dependencies
         run: |
-          python -m pip install -r requirements.txt
+          # Use wheels from feature branch for intermediate testing
+          python -m pip install ./deps/openassetio-*cp39*-manylinux_*_x86_64.whl
+          # python -m pip install -r requirements.txt
           python -m pip install .
 
       - name: Lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,15 +10,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
-        python: ['3.7', '3.9', '3.10']
+        # Constrain to single version to simplify install from wheels
+        os: ['ubuntu-latest']
+        python: ['3.7']
+        # os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
+        # python: ['3.7', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v3
+
+      - name: Download wheels from commit OpenAssetIO feature branch
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build-wheels.yml
+          workflow_conclusion: success
+          name: openassetio-wheels
+          repo: OpenAssetIO/OpenAssetIO
+          branch: feature/relatedReferencesRefactor
+          path: deps
+
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - run: |
-          python -m pip install -r requirements.txt
+          # Use wheels from feature branch for intermediate testing
+          python -m pip install ./deps/openassetio-*cp37*-manylinux_*_x86_64.whl
+          # python -m pip install -r requirements.txt
           python -m pip install -r tests/requirements.txt
           python -m pip install .
           python -m pytest -v ./tests

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,11 @@ Release Notes
 v1.0.0-alpha.X
 --------------
 
+### Breaking Changes
+
+- Minimum OpenAssetIO version increased to `v1.0.0-alpha.11` due to API
+  change.
+
 ### Improvements
 
 - Moved `openassetio` dependency out of python project

--- a/plugin/openassetio_manager_bal/BasicAssetLibraryInterface.py
+++ b/plugin/openassetio_manager_bal/BasicAssetLibraryInterface.py
@@ -196,24 +196,34 @@ class BasicAssetLibraryInterface(ManagerInterface):
                 )
                 successCallback(idx, self.__build_entity_ref(updated_entity_info))
 
-    def getRelatedReferences(
-        self, entityRefs, relationshipTraitsDatas, context, hostSession, resultTraitSet=None
+    def getWithRelationship(
+        self, relationshipTraitsData, entityReferences, context, hostSession, resultTraitSet=None
     ):
         results = []
 
-        # The inputs are either equal length arrays with index-wise
-        # correspondence, or, one of refs or relationships will have a
-        # single element that should be used for each entry in the
-        # other.
-        fill_value = entityRefs[0] if len(entityRefs) == 1 else relationshipTraitsDatas[0]
-
-        for entity_ref, relation_traits in itertools.zip_longest(
-            entityRefs, relationshipTraitsDatas, fillvalue=fill_value
-        ):
+        for entity_ref in entityReferences:
             entity_info = bal.parse_entity_ref(entity_ref.toString())
             relations = bal.related_references(
                 entity_info,
-                self.__traits_data_to_dict(relation_traits),
+                self.__traits_data_to_dict(relationshipTraitsData),
+                resultTraitSet,
+                self.__library,
+            )
+            # Convert the EntityInfos to entity references
+            results.append([self.__build_entity_ref(i) for i in relations])
+
+        return results
+
+    def getWithRelationships(
+        self, relationshipTraitsDatas, entityReference, context, hostSession, resultTraitSet=None
+    ):
+        results = []
+
+        for relationship in relationshipTraitsDatas:
+            entity_info = bal.parse_entity_ref(entityReference.toString())
+            relations = bal.related_references(
+                entity_info,
+                self.__traits_data_to_dict(relationship),
                 resultTraitSet,
                 self.__library,
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-openassetio == 1.0.0a9
+openassetio == 1.0.0a11

--- a/tests/bal_business_logic_suite.py
+++ b/tests/bal_business_logic_suite.py
@@ -437,7 +437,7 @@ class Test_register(FixtureAugmentedTestCase):
         return published_refs[0]
 
 
-class Test_getRelatedRefrences(LibraryOverrideTestCase):
+class Test_getWithRelationship(LibraryOverrideTestCase):
     # @TODO(tc) Switch to fixtures once covered by the OpenAssetIO
     # apiComplianceSuite as this should really be tested there. This
     # will be added when the C++ port happens along with the switch to
@@ -463,9 +463,9 @@ class Test_getRelatedRefrences(LibraryOverrideTestCase):
             "bal:///entity/proxy/3",
         )
 
-        result = self._manager.getRelatedReferences(
+        result = self._manager.getWithRelationship(
+            self._proxy_relation,
             self.__refs("bal:///entity/original"),
-            [self._proxy_relation],
             self.createTestContext(access=Context.Access.kRead),
         )
 
@@ -479,9 +479,9 @@ class Test_getRelatedRefrences(LibraryOverrideTestCase):
         filtered_proxy_relation = TraitsData(self._proxy_relation)
         filtered_proxy_relation.setTraitProperty(self._proxy_trait_id, "type", "alt")
 
-        result = self._manager.getRelatedReferences(
+        result = self._manager.getWithRelationship(
+            filtered_proxy_relation,
             self.__refs("bal:///entity/original"),
-            [filtered_proxy_relation],
             self.createTestContext(access=Context.Access.kRead),
         )
 
@@ -490,52 +490,24 @@ class Test_getRelatedRefrences(LibraryOverrideTestCase):
     def test_when_resultTraitSet_specified_then_only_those_containing_trait_set_returned(self):
         expected_refs = self.__refs("bal:///entity/proxy/2", "bal:///entity/proxy/3")
 
-        result = self._manager.getRelatedReferences(
+        result = self._manager.getWithRelationship(
+            self._proxy_relation,
             self.__refs("bal:///entity/original"),
-            [self._proxy_relation],
             self.createTestContext(access=Context.Access.kRead),
             resultTraitSet={"b"},
         )
 
         self.assertEqual(result, [expected_refs])
 
-    def test_when_single_ref_and_multiple_relations_supplied_then_ref_is_used_for_all(self):
-        expected_refs = [
-            self.__refs("bal:///entity/proxy/1", "bal:///entity/proxy/2", "bal:///entity/proxy/3"),
-            self.__refs("bal:///entity/source"),
-        ]
-
-        result = self._manager.getRelatedReferences(
-            self.__refs("bal:///entity/original"),
-            [self._proxy_relation, TraitsData({self._source_trait_id})],
-            self.createTestContext(access=Context.Access.kRead),
-        )
-
-        self.assertEqual(result, expected_refs)
-
-    def test_when_multiple_refs_and_single_relation_supplied_then_relation_us_used_for_all(self):
+    def test_when_multiple_refs_supplied_then_order_of_result_is_correct(self):
         expected_refs = [
             self.__refs("bal:///entity/proxy/1", "bal:///entity/proxy/2", "bal:///entity/proxy/3"),
             [],
         ]
 
-        result = self._manager.getRelatedReferences(
+        result = self._manager.getWithRelationship(
+            self._proxy_relation,
             self.__refs("bal:///entity/original", "bal:///entity/source"),
-            [self._proxy_relation],
-            self.createTestContext(access=Context.Access.kRead),
-        )
-
-        self.assertEqual(result, expected_refs)
-
-    def test_when_multiple_refs_and_relations_supplied_then_matched_index_wise(self):
-        expected_refs = [
-            self.__refs("bal:///entity/proxy/1", "bal:///entity/proxy/2", "bal:///entity/proxy/3"),
-            self.__refs("bal:///entity/original"),
-        ]
-
-        result = self._manager.getRelatedReferences(
-            self.__refs("bal:///entity/original", "bal:///entity/source"),
-            [self._proxy_relation, TraitsData({"derived"})],
             self.createTestContext(access=Context.Access.kRead),
         )
 
@@ -543,20 +515,117 @@ class Test_getRelatedRefrences(LibraryOverrideTestCase):
 
     def test_when_relation_not_in_library_then_exception_raised(self):
         with self.assertRaises(RuntimeError) as ex:
-            self._manager.getRelatedReferences(
+            self._manager.getWithRelationship(
+                TraitsData({"missing"}),
                 self.__refs("bal:///entity/original"),
-                [TraitsData({"missing"})],
                 self.createTestContext(access=Context.Access.kRead),
             )
         self.assertEqual(str(ex.exception), "Unknown BAL entity: 'missingEntity'")
 
 
-class Test_getRelatedRefrences_relations_data_missing(FixtureAugmentedTestCase):
+class Test_getWithRelationship_relations_data_missing(FixtureAugmentedTestCase):
     def test_when_library_missing_relations_data_then_empty_result_is_returned(self):
         # The standard library has no relations data
-        result = self._manager.getRelatedReferences(
-            self._manager.createEntityReference("bal:///another 𝓐𝓼𝓼𝓼𝓮𝔱"),
+        result = self._manager.getWithRelationship(
+            TraitsData({"someTrait"}),
+            [self._manager.createEntityReference("bal:///another 𝓐𝓼𝓼𝓼𝓮𝔱")],
+            self.createTestContext(access=Context.Access.kRead),
+        )
+        self.assertEqual(result, [[]])
+
+
+class Test_getWithRelationships(LibraryOverrideTestCase):
+    # @TODO(tc) Switch to fixtures once covered by the OpenAssetIO
+    # apiComplianceSuite as this should really be tested there. This
+    # will be added when the C++ port happens along with the switch to
+    # callback-based signatures.
+
+    _library = "library_business_logic_suite_related_references.json"
+
+    _proxy_trait_id = "proxy"
+    _source_trait_id = "source"
+
+    _proxy_relation = TraitsData({_proxy_trait_id})
+
+    def __refs(self, *args):
+        """
+        Converts string args to entity references
+        """
+        return [self._manager.createEntityReference(ref_str) for ref_str in args]
+
+    def test_when_called_with_no_relation_properties_then_all_matching_trait_set_returned(self):
+        expected_refs = self.__refs(
+            "bal:///entity/proxy/1",
+            "bal:///entity/proxy/2",
+            "bal:///entity/proxy/3",
+        )
+
+        result = self._manager.getWithRelationships(
+            [self._proxy_relation],
+            self._manager.createEntityReference("bal:///entity/original"),
+            self.createTestContext(access=Context.Access.kRead),
+        )
+
+        self.assertEqual(result, [expected_refs])
+
+    def test_when_called_with_relation_properties_then_only_those_matching_traits_data_returned(
+        self,
+    ):
+        expected_refs = self.__refs("bal:///entity/proxy/3")
+
+        filtered_proxy_relation = TraitsData(self._proxy_relation)
+        filtered_proxy_relation.setTraitProperty(self._proxy_trait_id, "type", "alt")
+
+        result = self._manager.getWithRelationships(
+            [filtered_proxy_relation],
+            self._manager.createEntityReference("bal:///entity/original"),
+            self.createTestContext(access=Context.Access.kRead),
+        )
+
+        self.assertEqual(result, [expected_refs])
+
+    def test_when_resultTraitSet_specified_then_only_those_containing_trait_set_returned(self):
+        expected_refs = self.__refs("bal:///entity/proxy/2", "bal:///entity/proxy/3")
+
+        result = self._manager.getWithRelationships(
+            [self._proxy_relation],
+            self._manager.createEntityReference("bal:///entity/original"),
+            self.createTestContext(access=Context.Access.kRead),
+            resultTraitSet={"b"},
+        )
+
+        self.assertEqual(result, [expected_refs])
+
+    def test_when_multiple_relations_supplied_then_ordering_is_correct(self):
+        expected_refs = [
+            self.__refs("bal:///entity/proxy/1", "bal:///entity/proxy/2", "bal:///entity/proxy/3"),
+            self.__refs("bal:///entity/source"),
+        ]
+
+        result = self._manager.getWithRelationships(
+            [self._proxy_relation, TraitsData({self._source_trait_id})],
+            self._manager.createEntityReference("bal:///entity/original"),
+            self.createTestContext(access=Context.Access.kRead),
+        )
+
+        self.assertEqual(result, expected_refs)
+
+    def test_when_relation_not_in_library_then_exception_raised(self):
+        with self.assertRaises(RuntimeError) as ex:
+            self._manager.getWithRelationships(
+                [TraitsData({"missing"})],
+                self._manager.createEntityReference("bal:///entity/original"),
+                self.createTestContext(access=Context.Access.kRead),
+            )
+        self.assertEqual(str(ex.exception), "Unknown BAL entity: 'missingEntity'")
+
+
+class Test_getWithRelationships_relations_data_missing(FixtureAugmentedTestCase):
+    def test_when_library_missing_relations_data_then_empty_result_is_returned(self):
+        # The standard library has no relations data
+        result = self._manager.getWithRelationships(
             [TraitsData({"someTrait"})],
+            self._manager.createEntityReference("bal:///another 𝓐𝓼𝓼𝓼𝓮𝔱"),
             self.createTestContext(access=Context.Access.kRead),
         )
         self.assertEqual(result, [[]])


### PR DESCRIPTION
Keeps parity with OpenAssetIO feature branch to facilitate e2e tests.

Experiments with using wheels from the OpenAssetIO feature branch to keep the tests working without the need for a custom OpenAssetIO build. Would be nice to wrap this up in an action that can detect the right platform/python version and install the right wheel.

Closes #34 