### PR TITLE
Migrate `getRelatedReferences` to new signatures

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -29,11 +29,22 @@ jobs:
         with:
           python-version: "3.9"
 
+      - name: Download wheels from commit OpenAssetIO feature branch
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build-wheels.yml
+          workflow_conclusion: success
+          name: openassetio-wheels
+          repo: OpenAssetIO/OpenAssetIO
+          path: deps
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install setuptools wheel
-          python -m pip install -r requirements.txt
+          # Use wheels from feature branch for intermediate testing
+          python -m pip install ./deps/openassetio-*cp39*-manylinux_*_x86_64.whl
+          # python -m pip install -r requirements.txt
 
       - name: Build wheels
         run: pip wheel --no-deps --wheel-dir wheelhouse .

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -13,9 +13,20 @@ jobs:
         with:
           python-version: 3.9
 
+      - name: Download wheels from commit OpenAssetIO feature branch
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build-wheels.yml
+          workflow_conclusion: success
+          name: openassetio-wheels
+          repo: OpenAssetIO/OpenAssetIO
+          path: deps
+
       - name: Install dependencies
         run: |
-          python -m pip install -r requirements.txt
+          # Use wheels from feature branch for intermediate testing
+          python -m pip install ./deps/openassetio-*cp39*-manylinux_*_x86_64.whl
+          # python -m pip install -r requirements.txt
           python -m pip install -r tests/requirements.txt
           python -m pip install .
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,15 +10,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
-        python: ['3.7', '3.9', '3.10']
+        # Constrain to single version to simplify install from wheels
+        os: ['ubuntu-latest']
+        python: ['3.7']
+        # os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
+        # python: ['3.7', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v3
+
+      - name: Download wheels from commit OpenAssetIO feature branch
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: build-wheels.yml
+          workflow_conclusion: success
+          name: openassetio-wheels
+          repo: OpenAssetIO/OpenAssetIO
+          path: deps
+
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - run: |
-          python -m pip install -r requirements.txt
+          # Use wheels from feature branch for intermediate testing
+          python -m pip install ./deps/openassetio-*cp37*-manylinux_*_x86_64.whl
+          # python -m pip install -r requirements.txt
           python -m pip install -r tests/requirements.txt
           python -m pip install .
           python -m pytest -v ./tests

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,14 @@
 Release Notes
 =============
 
+v1.0.0-alpha.x
+--------------
+
+### Breaking Changes
+
+- Refactored error handling. `BatchElementError` messages have been
+  reformatted when a referenced entity is missing from the library.
+
 v1.0.0-alpha.8
 --------------
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,9 @@ v1.0.0-alpha.x
 
 ### Breaking Changes
 
+- Minimum OpenAssetIO version increased to `v1.0.0-alpha.13` due to API
+  changes.
+
 - Refactored error handling. `BatchElementError` messages have been
   reformatted when a referenced entity is missing from the library.
 

--- a/plugin/openassetio_manager_bal/BasicAssetLibraryInterface.py
+++ b/plugin/openassetio_manager_bal/BasicAssetLibraryInterface.py
@@ -20,7 +20,6 @@
 A single-class module, providing the BasicAssetLibraryInterface class.
 """
 
-import itertools
 import os
 import time
 

--- a/plugin/openassetio_manager_bal/bal.py
+++ b/plugin/openassetio_manager_bal/bal.py
@@ -338,7 +338,7 @@ class UnknownBALEntity(RuntimeError):
     """
 
     def __init__(self, entity_info: EntityInfo):
-        super().__init__(f"Unknown BAL entity: '{entity_info.name}'")
+        super().__init__(f"Entity '{entity_info.name}' not found")
 
 
 class MalformedBALReference(RuntimeError):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-openassetio == 1.0.0a9
+openassetio == 1.0.0a13

--- a/tests/bal_business_logic_suite.py
+++ b/tests/bal_business_logic_suite.py
@@ -25,7 +25,7 @@ import os
 
 from unittest import mock
 
-from openassetio import Context, TraitsData
+from openassetio import BatchElementError, Context, TraitsData
 from openassetio.exceptions import PluginError
 from openassetio.test.manager.harness import FixtureAugmentedTestCase
 
@@ -437,7 +437,7 @@ class Test_register(FixtureAugmentedTestCase):
         return published_refs[0]
 
 
-class Test_getRelatedRefrences(LibraryOverrideTestCase):
+class Test_getWithRelationship(LibraryOverrideTestCase):
     # @TODO(tc) Switch to fixtures once covered by the OpenAssetIO
     # apiComplianceSuite as this should really be tested there. This
     # will be added when the C++ port happens along with the switch to
@@ -463,13 +463,19 @@ class Test_getRelatedRefrences(LibraryOverrideTestCase):
             "bal:///entity/proxy/3",
         )
 
-        result = self._manager.getRelatedReferences(
+        result_refs = [None]
+
+        self._manager.getWithRelationship(
+            self._proxy_relation,
             self.__refs("bal:///entity/original"),
-            [self._proxy_relation],
             self.createTestContext(access=Context.Access.kRead),
+            lambda idx, refs: operator.setitem(result_refs, idx, refs),
+            lambda _, err: self.fail(
+                f"getWithRelationship should not error: {err.code} {err.message}"
+            ),
         )
 
-        self.assertEqual(result, [expected_refs])
+        self.assertEqual(result_refs, [expected_refs])
 
     def test_when_called_with_relation_properties_then_only_those_matching_traits_data_returned(
         self,
@@ -479,84 +485,223 @@ class Test_getRelatedRefrences(LibraryOverrideTestCase):
         filtered_proxy_relation = TraitsData(self._proxy_relation)
         filtered_proxy_relation.setTraitProperty(self._proxy_trait_id, "type", "alt")
 
-        result = self._manager.getRelatedReferences(
+        result_refs = [None]
+
+        self._manager.getWithRelationship(
+            filtered_proxy_relation,
             self.__refs("bal:///entity/original"),
-            [filtered_proxy_relation],
             self.createTestContext(access=Context.Access.kRead),
+            lambda idx, refs: operator.setitem(result_refs, idx, refs),
+            lambda _, err: self.fail(
+                f"getWithRelationship should not error: {err.code} {err.message}"
+            ),
         )
 
-        self.assertEqual(result, [expected_refs])
+        self.assertEqual(result_refs, [expected_refs])
 
     def test_when_resultTraitSet_specified_then_only_those_containing_trait_set_returned(self):
         expected_refs = self.__refs("bal:///entity/proxy/2", "bal:///entity/proxy/3")
 
-        result = self._manager.getRelatedReferences(
+        result_refs = [None]
+
+        self._manager.getWithRelationship(
+            self._proxy_relation,
             self.__refs("bal:///entity/original"),
-            [self._proxy_relation],
             self.createTestContext(access=Context.Access.kRead),
+            lambda idx, refs: operator.setitem(result_refs, idx, refs),
+            lambda _, err: self.fail(
+                f"getWithRelationship should not error: {err.code} {err.message}"
+            ),
             resultTraitSet={"b"},
         )
 
-        self.assertEqual(result, [expected_refs])
+        self.assertEqual(result_refs, [expected_refs])
 
-    def test_when_single_ref_and_multiple_relations_supplied_then_ref_is_used_for_all(self):
-        expected_refs = [
-            self.__refs("bal:///entity/proxy/1", "bal:///entity/proxy/2", "bal:///entity/proxy/3"),
-            self.__refs("bal:///entity/source"),
-        ]
-
-        result = self._manager.getRelatedReferences(
-            self.__refs("bal:///entity/original"),
-            [self._proxy_relation, TraitsData({self._source_trait_id})],
-            self.createTestContext(access=Context.Access.kRead),
-        )
-
-        self.assertEqual(result, expected_refs)
-
-    def test_when_multiple_refs_and_single_relation_supplied_then_relation_us_used_for_all(self):
+    def test_when_multiple_refs_supplied_then_order_of_result_is_correct(self):
         expected_refs = [
             self.__refs("bal:///entity/proxy/1", "bal:///entity/proxy/2", "bal:///entity/proxy/3"),
             [],
         ]
 
-        result = self._manager.getRelatedReferences(
+        result_refs = [None] * len(expected_refs)
+
+        self._manager.getWithRelationship(
+            self._proxy_relation,
             self.__refs("bal:///entity/original", "bal:///entity/source"),
-            [self._proxy_relation],
             self.createTestContext(access=Context.Access.kRead),
+            lambda idx, refs: operator.setitem(result_refs, idx, refs),
+            lambda _, err: self.fail(
+                f"getWithRelationship should not error: {err.code} {err.message}"
+            ),
         )
 
-        self.assertEqual(result, expected_refs)
+        self.assertEqual(result_refs, expected_refs)
 
-    def test_when_multiple_refs_and_relations_supplied_then_matched_index_wise(self):
-        expected_refs = [
-            self.__refs("bal:///entity/proxy/1", "bal:///entity/proxy/2", "bal:///entity/proxy/3"),
+    def test_when_relation_not_in_library_then_error_callback_called_with_expected_error(self):
+        expected_error = BatchElementError(
+            BatchElementError.ErrorCode.kEntityResolutionError,
+            "Entity 'missingEntity' not found",
+        )
+
+        def check_error(idx, error):
+            self.assertEqual(idx, 0)
+            self.assertEqual(error, expected_error)
+
+        self._manager.getWithRelationship(
+            TraitsData({"missing"}),
             self.__refs("bal:///entity/original"),
-        ]
-
-        result = self._manager.getRelatedReferences(
-            self.__refs("bal:///entity/original", "bal:///entity/source"),
-            [self._proxy_relation, TraitsData({"derived"})],
             self.createTestContext(access=Context.Access.kRead),
+            lambda _, __: self.fail("getWithRelationship should fail"),
+            check_error,
         )
 
-        self.assertEqual(result, expected_refs)
 
-    def test_when_relation_not_in_library_then_exception_raised(self):
-        with self.assertRaises(RuntimeError) as ex:
-            self._manager.getRelatedReferences(
-                self.__refs("bal:///entity/original"),
-                [TraitsData({"missing"})],
-                self.createTestContext(access=Context.Access.kRead),
-            )
-        self.assertEqual(str(ex.exception), "Unknown BAL entity: 'missingEntity'")
-
-
-class Test_getRelatedRefrences_relations_data_missing(FixtureAugmentedTestCase):
+class Test_getWithRelationship_relations_data_missing(FixtureAugmentedTestCase):
     def test_when_library_missing_relations_data_then_empty_result_is_returned(self):
         # The standard library has no relations data
-        result = self._manager.getRelatedReferences(
-            self._manager.createEntityReference("bal:///another 𝓐𝓼𝓼𝓼𝓮𝔱"),
-            [TraitsData({"someTrait"})],
+        result_refs = [None]
+        self._manager.getWithRelationship(
+            TraitsData({"someTrait"}),
+            [self._manager.createEntityReference("bal:///another 𝓐𝓼𝓼𝓼𝓮𝔱")],
             self.createTestContext(access=Context.Access.kRead),
+            lambda idx, refs: operator.setitem(result_refs, idx, refs),
+            lambda _, err: self.fail(
+                f"getWithRelationship should not error: {err.code} {err.message}"
+            ),
         )
-        self.assertEqual(result, [[]])
+        self.assertEqual(result_refs, [[]])
+
+
+class Test_getWithRelationships(LibraryOverrideTestCase):
+    # @TODO(tc) Switch to fixtures once covered by the OpenAssetIO
+    # apiComplianceSuite as this should really be tested there. This
+    # will be added when the C++ port happens along with the switch to
+    # callback-based signatures.
+
+    _library = "library_business_logic_suite_related_references.json"
+
+    _proxy_trait_id = "proxy"
+    _source_trait_id = "source"
+
+    _proxy_relation = TraitsData({_proxy_trait_id})
+
+    def __refs(self, *args):
+        """
+        Converts string args to entity references
+        """
+        return [self._manager.createEntityReference(ref_str) for ref_str in args]
+
+    def test_when_called_with_no_relation_properties_then_all_matching_trait_set_returned(self):
+        expected_refs = self.__refs(
+            "bal:///entity/proxy/1",
+            "bal:///entity/proxy/2",
+            "bal:///entity/proxy/3",
+        )
+
+        result_refs = [None]
+
+        self._manager.getWithRelationships(
+            [self._proxy_relation],
+            self._manager.createEntityReference("bal:///entity/original"),
+            self.createTestContext(access=Context.Access.kRead),
+            lambda idx, refs: operator.setitem(result_refs, idx, refs),
+            lambda _, err: self.fail(
+                f"getWithRelationships should not error: {err.code} {err.message}"
+            ),
+        )
+
+        self.assertEqual(result_refs, [expected_refs])
+
+    def test_when_called_with_relation_properties_then_only_those_matching_traits_data_returned(
+        self,
+    ):
+        expected_refs = self.__refs("bal:///entity/proxy/3")
+
+        filtered_proxy_relation = TraitsData(self._proxy_relation)
+        filtered_proxy_relation.setTraitProperty(self._proxy_trait_id, "type", "alt")
+
+        result_refs = [None]
+
+        self._manager.getWithRelationships(
+            [filtered_proxy_relation],
+            self._manager.createEntityReference("bal:///entity/original"),
+            self.createTestContext(access=Context.Access.kRead),
+            lambda idx, refs: operator.setitem(result_refs, idx, refs),
+            lambda _, err: self.fail(
+                f"getWithRelationships should not error: {err.code} {err.message}"
+            ),
+        )
+
+        self.assertEqual(result_refs, [expected_refs])
+
+    def test_when_resultTraitSet_specified_then_only_those_containing_trait_set_returned(self):
+        expected_refs = self.__refs("bal:///entity/proxy/2", "bal:///entity/proxy/3")
+
+        result_refs = [None]
+
+        self._manager.getWithRelationships(
+            [self._proxy_relation],
+            self._manager.createEntityReference("bal:///entity/original"),
+            self.createTestContext(access=Context.Access.kRead),
+            lambda idx, refs: operator.setitem(result_refs, idx, refs),
+            lambda _, err: self.fail(
+                f"getWithRelationships should not error: {err.code} {err.message}"
+            ),
+            resultTraitSet={"b"},
+        )
+
+        self.assertEqual(result_refs, [expected_refs])
+
+    def test_when_multiple_relations_supplied_then_ordering_is_correct(self):
+        expected_refs = [
+            self.__refs("bal:///entity/proxy/1", "bal:///entity/proxy/2", "bal:///entity/proxy/3"),
+            self.__refs("bal:///entity/source"),
+        ]
+
+        result_refs = [None] * len(expected_refs)
+
+        self._manager.getWithRelationships(
+            [self._proxy_relation, TraitsData({self._source_trait_id})],
+            self._manager.createEntityReference("bal:///entity/original"),
+            self.createTestContext(access=Context.Access.kRead),
+            lambda idx, refs: operator.setitem(result_refs, idx, refs),
+            lambda _, err: self.fail(
+                f"getWithRelationships should not error: {err.code} {err.message}"
+            ),
+        )
+
+        self.assertEqual(result_refs, expected_refs)
+
+    def test_when_relation_not_in_library_then_error_callback_called_with_expected_error(self):
+        expected_error = BatchElementError(
+            BatchElementError.ErrorCode.kEntityResolutionError,
+            "Entity 'missingEntity' not found",
+        )
+
+        def check_error(idx, error):
+            self.assertEqual(idx, 0)
+            self.assertEqual(error, expected_error)
+
+        self._manager.getWithRelationships(
+            [TraitsData({"missing"})],
+            self._manager.createEntityReference("bal:///entity/original"),
+            self.createTestContext(access=Context.Access.kRead),
+            lambda _, __: self.fail("getWithRelationships should fail"),
+            check_error,
+        )
+
+
+class Test_getWithRelationships_relations_data_missing(FixtureAugmentedTestCase):
+    def test_when_library_missing_relations_data_then_empty_result_is_returned(self):
+        # The standard library has no relations data
+        result_refs = [None]
+        self._manager.getWithRelationships(
+            [TraitsData({"someTrait"})],
+            self._manager.createEntityReference("bal:///another 𝓐𝓼𝓼𝓼𝓮𝔱"),
+            self.createTestContext(access=Context.Access.kRead),
+            lambda idx, refs: operator.setitem(result_refs, idx, refs),
+            lambda _, err: self.fail(
+                f"getWithRelationships should not error: {err.code} {err.message}"
+            ),
+        )
+        self.assertEqual(result_refs, [[]])

--- a/tests/bal_functional_behaviour_suite.py
+++ b/tests/bal_functional_behaviour_suite.py
@@ -90,16 +90,28 @@ class Test_simulated_latency(FixtureAugmentedTestCase):
             self.createTestContext(access=Context.Access.kRead),
         )
 
-    def test_when_getRelatedReferences_called_then_results_delayed_by_specified_query_latency(
+    def test_when_getWithRelationship_called_then_results_delayed_by_specified_query_latency(
         self,
     ):
         entity_refs = self.create_test_entity_references()
-        traits_datas = [TraitsData() for _ in entity_refs]
 
-        self.__check_simulated_latencies_without_callbacks(
-            self._manager.getRelatedReferences,
+        self.__check_simulated_latencies_with_callbacks(
+            self._manager.getWithRelationship,
+            TraitsData(),
             entity_refs,
+            self.createTestContext(access=Context.Access.kRead),
+        )
+
+    def test_when_getWithRelationships_called_then_results_delayed_by_specified_query_latency(
+        self,
+    ):
+        entity_ref = self.create_test_entity_references()[0]
+        traits_datas = [TraitsData()] * 3
+
+        self.__check_simulated_latencies_with_callbacks(
+            self._manager.getWithRelationships,
             traits_datas,
+            entity_ref,
             self.createTestContext(access=Context.Access.kRead),
         )
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -90,7 +90,7 @@ fixtures = {
             "the_error_string_for_a_reference_to_a_readonly_entity": "BAL entities are read-only",
             "a_reference_to_a_missing_entity": "bal:///missing_entity",
             "the_error_string_for_a_reference_to_a_missing_entity": (
-                "Entity 'bal:///missing_entity' not found"
+                "Entity 'missing_entity' not found"
             ),
             "a_malformed_reference": MALFORMED_REF,
             "the_error_string_for_a_malformed_reference": (


### PR DESCRIPTION
Provides a cleaned up version of [`feature/relatedReferencesRefactor`](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/tree/feature/relatedReferencesRefactor), this should only be merged after https://github.com/OpenAssetIO/OpenAssetIO/pull/951.

Diff to the current feature branch [here](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/compare/77c334a..3bd89ab).

Closes #42 
