### PR TITLE
[Tests] Fix OpenAssetIO `constants` import

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -21,7 +21,7 @@ import json
 import os
 
 from openassetio import TraitsData
-from openassetio.constants import kField_EntityReferencesMatchPrefix
+from openassetio import constants
 
 
 #
@@ -68,7 +68,7 @@ fixtures = {
     "Test_identifier": {"test_matches_fixture": {"identifier": IDENTIFIER}},
     "Test_displayName": {"test_matches_fixture": {"display_name": "Basic Asset Library 📖"}},
     "Test_info": {
-        "test_matches_fixture": {"info": {kField_EntityReferencesMatchPrefix: "bal:///"}}
+        "test_matches_fixture": {"info": {constants.kField_EntityReferencesMatchPrefix: "bal:///"}}
     },
     "Test_initialize": {
         "shared": {


### PR DESCRIPTION
In OpenAssetIO/OpenAssetIO#998 the `constants` module was migrated to C++ as a CPython submodule. This means, annoyingly, that we can no longer import objects `from` the `constants` module. Instead, we must import the `constants` module wholesale.