### PR TITLE
Migrate entityExists to callback based API

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,8 +9,7 @@ v1.0.0-alpha.x
 - Refactored entity reference handling, resulting in a change to
   exception message formatting for malformed entity references.
 
-- Fixed return of `entityExists` when the input ref is invalid, this now
-  returns `False` for that element instead of raising an exception.
+- Migrated `entityExists` to the batch-first callback based signature.
 
 ### New features
 

--- a/plugin/openassetio_manager_bal/BasicAssetLibraryInterface.py
+++ b/plugin/openassetio_manager_bal/BasicAssetLibraryInterface.py
@@ -147,15 +147,15 @@ class BasicAssetLibraryInterface(ManagerInterface):
         return someString.startswith(self.__entity_refrence_prefix())
 
     @simulated_delay
-    def entityExists(self, entityRefs, context, hostSession):
+    def entityExists(self, entityRefs, _context, _hostSession, successCallback, errorCallback):
         results = []
-        for ref in entityRefs:
+        for idx, ref in enumerate(entityRefs):
             try:
                 entity_info = self.__parse_entity_ref(ref.toString())
                 result = bal.exists(entity_info, self.__library)
-            except MalformedEntityReference:
-                result = False
-            results.append(result)
+                successCallback(idx, result)
+            except Exception as exc:  # pylint: disable=broad-except
+                self.__handle_exception(exc, idx, errorCallback)
         return results
 
     @simulated_delay

--- a/tests/bal_business_logic_suite.py
+++ b/tests/bal_business_logic_suite.py
@@ -144,7 +144,15 @@ class Test_initialize_entity_reference_scheme(FixtureAugmentedTestCase):
 
         # Assert prefix used for queries
         ref = self._manager.createEntityReference(f"{prefix}anAsset⭐︎")
-        self.assertTrue(self._manager.entityExists([ref], context)[0])
+
+        self._manager.entityExists(
+            [ref],
+            context,
+            lambda idx, exists: self.assertTrue(exists),
+            lambda idx, error: self.fail(
+                f"Failed to check existence of reference: {error.message}"
+            ),
+        )
 
         # Assert prefix used to generate new references
         published_refs = [None]
@@ -420,7 +428,14 @@ class Test_register(FixtureAugmentedTestCase):
         published_entity_ref = self.__create_test_entity(new_entity_ref, data, context)
 
         context.access = Context.Access.kRead
-        self.assertTrue(self._manager.entityExists([published_entity_ref], context)[0])
+        self._manager.entityExists(
+            [published_entity_ref],
+            context,
+            lambda idx, exists: self.assertTrue(exists),
+            lambda idx, error: self.fail(
+                f"Failed to check existence of reference: {error.message}"
+            ),
+        )
         self.assertEqual(published_entity_ref, new_entity_ref)
 
     def test_when_ref_exists_then_entity_updated_with_same_reference(self):
@@ -470,9 +485,16 @@ class Test_register(FixtureAugmentedTestCase):
         old_access = context.access
 
         context.access = Context.Access.kRead
-        self.assertFalse(
-            self._manager.entityExists([ref], context)[0],
-            f"Entity '{ref.toString()}' already exists",
+
+        self._manager.entityExists(
+            [ref],
+            context,
+            lambda idx, exists: self.assertFalse(
+                exists, f"Entity '{ref.toString()}' already exists"
+            ),
+            lambda idx, error: self.fail(
+                f"Failed to check existence of reference: {error.message}"
+            ),
         )
 
         published_refs = [None]

--- a/tests/bal_functional_behaviour_suite.py
+++ b/tests/bal_functional_behaviour_suite.py
@@ -57,7 +57,7 @@ class Test_simulated_latency(FixtureAugmentedTestCase):
     __test_query_latencies = [0, 2500.5, 5000]
 
     def test_when_resolve_called_then_results_delayed_by_specified_simulated_query_latency(self):
-        self.__check_simulated_latencies_with_callbacks(
+        self.__check_simulated_latencies(
             self._manager.resolve,
             self.create_test_entity_references(),
             {"string"},
@@ -67,7 +67,7 @@ class Test_simulated_latency(FixtureAugmentedTestCase):
     def test_when_preflight_called_then_results_delayed_by_specified_simulated_query_latency(self):
         entity_references = self.create_test_entity_references()
         traits_datas = [TraitsData({"string"})] * len(entity_references)
-        self.__check_simulated_latencies_with_callbacks(
+        self.__check_simulated_latencies(
             self._manager.preflight,
             entity_references,
             traits_datas,
@@ -77,7 +77,7 @@ class Test_simulated_latency(FixtureAugmentedTestCase):
     def test_when_entityExists_called_then_results_delayed_by_specified_simulated_query_latency(
         self,
     ):
-        self.__check_simulated_latencies_without_callbacks(
+        self.__check_simulated_latencies(
             self._manager.entityExists,
             self.create_test_entity_references(),
             self.createTestContext(access=Context.Access.kRead),
@@ -87,7 +87,7 @@ class Test_simulated_latency(FixtureAugmentedTestCase):
         entity_refs = self.create_test_entity_references()
         traits_datas = [TraitsData() for _ in entity_refs]
 
-        self.__check_simulated_latencies_with_callbacks(
+        self.__check_simulated_latencies(
             self._manager.register,
             entity_refs,
             traits_datas,
@@ -99,7 +99,7 @@ class Test_simulated_latency(FixtureAugmentedTestCase):
     ):
         entity_refs = self.create_test_entity_references()
 
-        self.__check_simulated_latencies_with_callbacks(
+        self.__check_simulated_latencies(
             self._manager.getWithRelationship,
             entity_refs,
             TraitsData(),
@@ -112,7 +112,7 @@ class Test_simulated_latency(FixtureAugmentedTestCase):
         entity_ref = self.create_test_entity_references()[0]
         traits_datas = [TraitsData()] * 3
 
-        self.__check_simulated_latencies_with_callbacks(
+        self.__check_simulated_latencies(
             self._manager.getWithRelationships,
             entity_ref,
             traits_datas,
@@ -124,7 +124,7 @@ class Test_simulated_latency(FixtureAugmentedTestCase):
     ):
         entity_refs = self.create_test_entity_references()
 
-        self.__check_simulated_latencies_with_callbacks(
+        self.__check_simulated_latencies(
             self._manager.getWithRelationshipPaged,
             entity_refs,
             TraitsData(),
@@ -138,7 +138,7 @@ class Test_simulated_latency(FixtureAugmentedTestCase):
         entity_ref = self.create_test_entity_references()[0]
         traits_datas = [TraitsData()] * 3
 
-        self.__check_simulated_latencies_with_callbacks(
+        self.__check_simulated_latencies(
             self._manager.getWithRelationshipsPaged,
             entity_ref,
             traits_datas,
@@ -236,15 +236,10 @@ class Test_simulated_latency(FixtureAugmentedTestCase):
         else:
             patched_time_sleep.assert_not_called()
 
-    def __check_simulated_latencies_with_callbacks(self, method, *args, **kwargs):
+    def __check_simulated_latencies(self, method, *args, **kwargs):
         for query_latency in self.__simulated_latency_subtests():
             with self.__assert_simulated_latency_applied(query_latency):
                 method(*args, mock.Mock(), mock.Mock(), **kwargs)
-
-    def __check_simulated_latencies_without_callbacks(self, method, *args, **kwargs):
-        for query_latency in self.__simulated_latency_subtests():
-            with self.__assert_simulated_latency_applied(query_latency):
-                method(*args, **kwargs)
 
     def __simulated_latency_subtests(self):
         for query_latency in self.__test_query_latencies:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -114,8 +114,18 @@ fixtures = {
     "Test_entityExists": {
         "shared": {
             "a_reference_to_an_existing_entity": f"bal:///{an_existing_entity_name}",
+        },
+        "test_when_querying_existing_reference_then_true_is_returned": {},
+        "test_when_querying_nonexisting_reference_then_false_is_returned": {
+            "a_reference_to_a_nonexisting_entity": VALID_REF
+        },
+        "test_when_querying_existing_and_nonexisting_references_then_true_and_false_is_returned": {
             "a_reference_to_a_nonexisting_entity": VALID_REF,
-        }
+        },
+        "test_when_querying_malformed_reference_then_malformed_reference_error_is_returned": {
+            "a_malformed_reference": MALFORMED_REF,
+            "expected_error_message": ERROR_MSG_MALFORMED_REF,
+        },
     },
     "Test_resolve": {
         "shared": {


### PR DESCRIPTION
Part of OpenAssetIO/OpenAssetIO#993

Note that this changes the (unreleased) behaviour of treating malformed entity references as `False` for existence, instead raising the appropriate `BatchElementError`.