### PR TITLE
Validate access mode for API functions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,6 +17,10 @@ v1.0.0-alpha.x
 
 - Added a runtime dependency on the `openassetio-mediacreation` package.
 
+- Added validation to API methods to error on unsupported
+  `Context.Access` modes.
+  [#57](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/57)
+
 ### New features
 
 - The entity reference scheme consumed by BAL can be adjusted from the

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -132,7 +132,9 @@ fixtures = {
             "a_reference_to_a_readable_entity": f"bal:///{an_existing_entity_name}",
             "a_set_of_valid_traits": {"string", "number"},
             "a_reference_to_a_readonly_entity": f"bal:///{an_existing_entity_name}",
-            "the_error_string_for_a_reference_to_a_readonly_entity": "BAL entities are read-only",
+            "the_error_string_for_a_reference_to_a_readonly_entity": (
+                "Unsupported access mode for resolve"
+            ),
             "a_reference_to_a_missing_entity": "bal:///missing_entity",
             "the_error_string_for_a_reference_to_a_missing_entity": ERROR_MSG_MISSING_ENTITY,
             "a_malformed_reference": MALFORMED_REF,


### PR DESCRIPTION
Closes https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/57.  See corresponding PR https://github.com/OpenAssetIO/OpenAssetIO/pull/1050

https://github.com/OpenAssetIO/OpenAssetIO/issues/1016 refined the Context access patterns to formalize the creation of "children" and other related entities via publish to an existing reference. BAL does not yet support this kind of creation, and so should error in the case.

So respond appropriately to Access mode in various API functions, by calling the provided error callback, except in the case of `managementPolicy` which responds with empty `TraitsData` objects (signifying "unmanaged").

Note that for consistency, this changes the error message output when attempting to `resolve` with `kWrite` access.