### PR TITLE
[Core] Make `openassetio-mediacreation` a soft dependency

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,14 @@
 Release Notes
 =============
 
+v1.0.0-alpha.x
+---------------
+
+### Bug fixes
+
+- Made `openassetio-mediacreation` a soft dependency to avoid
+  conflicting installation requirements.
+
 v1.0.0-alpha.10
 ---------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@
 name = "openassetio-manager-bal"
 version = "1.0.0a10"
 requires-python = ">=3.7"
-dependencies = ["openassetio-mediacreation>=1.0.0a7"]
 
 authors = [
   { name = "Contributors to the OpenAssetIO project", email = "openassetio-discussion@lists.aswf.io" }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 openassetio==1.0.0a14
+openassetio-mediacreation>=1.0.0a7


### PR DESCRIPTION
This was causing issues as presenty, Media Creation has an install dependency on `openassetio`. We deliberately made this a soft dependency in BAL as it is always provided by the host.