### PR TITLE
Add hasCapability

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,7 @@ v1.0.0-alpha.xx
 
 - Minimum OpenAssetIO version increased to v1.0.0-beta.1 due to
   breaking API changes.
+  [#1119](https://github.com/OpenAssetIO/OpenAssetIO/issues/1119)
   [#1125](https://github.com/OpenAssetIO/OpenAssetIO/issues/1125)
   [#1127](https://github.com/OpenAssetIO/OpenAssetIO/issues/1127)
 

--- a/plugin/openassetio_manager_bal/BasicAssetLibraryInterface.py
+++ b/plugin/openassetio_manager_bal/BasicAssetLibraryInterface.py
@@ -111,6 +111,19 @@ class BasicAssetLibraryInterface(ManagerInterface):
     def settings(self, hostSession):
         return self.__settings.copy()
 
+    def hasCapability(self, capability):
+        if capability in (
+            ManagerInterface.Capability.kEntityReferenceIdentification,
+            ManagerInterface.Capability.kManagementPolicyQueries,
+            ManagerInterface.Capability.kResolution,
+            ManagerInterface.Capability.kPublishing,
+            ManagerInterface.Capability.kRelationshipQueries,
+            ManagerInterface.Capability.kExistenceQueries,
+        ):
+            return True
+
+        return False
+
     @property
     def simulated_latency(self):
         """

--- a/tests/bal_business_logic_suite.py
+++ b/tests/bal_business_logic_suite.py
@@ -27,6 +27,8 @@ import os
 from unittest import mock
 
 from openassetio import constants
+from openassetio.hostApi import Manager
+from openassetio.managerApi import ManagerInterface
 from openassetio.access import PolicyAccess, PublishingAccess, RelationsAccess, ResolveAccess
 from openassetio.errors import (
     BatchElementError,
@@ -43,6 +45,10 @@ from openassetio_mediacreation.specifications.lifecycle import (
     StableEntityVersionsRelationshipSpecification,
 )
 
+# pylint can't load this module simply, we just want to import it to
+# test the asymmetric manager/managerInterface capabilities enum.
+# pylint: disable=E0401
+from openassetio_manager_bal.BasicAssetLibraryInterface import BasicAssetLibraryInterface
 
 __all__ = []
 
@@ -306,6 +312,31 @@ class Test_managementPolicy_library_specified_behavior(LibraryOverrideTestCase):
         actual = self._manager.managementPolicy(trait_sets, PolicyAccess.kCreateRelated, context)
 
         self.assertListEqual(actual, expected)
+
+
+class Test_hasCapability(FixtureAugmentedTestCase):
+    """
+    Tests that BAL reports expected capabilities
+    """
+
+    def test_when_hasCapability_called_then_expected_capabilities_reported(self):
+        self.assertFalse(self._manager.hasCapability(Manager.Capability.kStatefulContexts))
+        self.assertFalse(self._manager.hasCapability(Manager.Capability.kCustomTerminology))
+        self.assertFalse(self._manager.hasCapability(Manager.Capability.kDefaultEntityReferences))
+
+        self.assertTrue(self._manager.hasCapability(Manager.Capability.kResolution))
+        self.assertTrue(self._manager.hasCapability(Manager.Capability.kPublishing))
+        self.assertTrue(self._manager.hasCapability(Manager.Capability.kRelationshipQueries))
+        self.assertTrue(self._manager.hasCapability(Manager.Capability.kExistenceQueries))
+
+    def test_when_hasCapability_called_on_managerInterface_then_has_mandatory_capabilities(self):
+        interface = BasicAssetLibraryInterface()
+        self.assertTrue(
+            interface.hasCapability(ManagerInterface.Capability.kEntityReferenceIdentification)
+        )
+        self.assertTrue(
+            interface.hasCapability(ManagerInterface.Capability.kManagementPolicyQueries)
+        )
 
 
 class Test_resolve(FixtureAugmentedTestCase):


### PR DESCRIPTION
Adds hasCapability to BAL, along with a test case in the business logic suite.

Has a drop commit to https://github.com/OpenAssetIO/OpenAssetIO/pull/1126, and serves as the confirmation test.