### PR TITLE
Add support for `StableReferenceRelationship` queries

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,16 @@
 Release Notes
 =============
 
+v1.0.0-alpha.xx
+---------------
+
+### New features
+
+- Added support for querying a stable equivalent reference using the
+  OpenAssetIO-MediaCreation `StableReferenceRelationshipSpecification`
+  with `getWithRelationship`.
+  [#83](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/pull/83)
+
 v1.0.0-alpha.12
 ---------------
 


### PR DESCRIPTION
Adds support for the ability to query a reference without dynamic behavior, so we can complete our working examples of MediaCreation defined versioning workflows.

Reviewer notes:
 - The first commit is a refactor to make the code a little more amenable to extension
 - The second adds the new functionality.

Closes #83 

