### PR TITLE
Support `kRequired` / `kManagerDriven` access modes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,11 @@ v1.0.0-alpha.xx (on release: reinstate `openassetio` dependency)
 - Added support for the `entityTraits` core API method.
   [#89](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/89)
 
+- Added support for the `kRequired` and `kManagerDriven` access modes in
+  `managementPolicy` queries. Added support for access modes other than
+  `kRead` in `resolve` queries (i.e. `kManagerDriven`).
+  [#98](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/98)
+
 v1.0.0-alpha.13
 ---------------
 

--- a/plugin/openassetio_manager_bal/bal.py
+++ b/plugin/openassetio_manager_bal/bal.py
@@ -30,7 +30,7 @@ import os
 import string
 
 from dataclasses import dataclass
-from typing import Dict, List, Set, Optional
+from typing import Dict, List, Set, Optional, Tuple
 
 
 @dataclass
@@ -55,6 +55,7 @@ class Entity:
     version: int
     traits: Dict[str, dict]
     relations: List[dict]
+    supported_access_modes: Tuple[str] = ("read",)
 
 
 @dataclass

--- a/schema.json
+++ b/schema.json
@@ -150,6 +150,201 @@
           },
           "required": ["default"],
           "additionalProperties": false
+        },
+        "required": {
+          "type": "object",
+          "description": "Custom managementPolicy responses for required access contexts",
+          "properties": {
+            "default": {
+              "description": "The default policy unless an exception is specified",
+              "type": "object",
+              "patternProperties": {
+                ".*": {
+                  "description": "The trait's property values.",
+                  "type": "object",
+                  "patternProperties": {
+                    ".*": {
+                      "type": [
+                        "string",
+                        "number",
+                        "boolean"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "exceptions": {
+              "descriptions": "Custom policies that override the default",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "description": "A policy for a specific trait set, that must match the request exactly",
+                "properties": {
+                  "traitSet": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "policy": {
+                    "type": "object",
+                    "patternProperties": {
+                      ".*": {
+                        "description": "The trait's property values.",
+                        "type": "object",
+                        "patternProperties": {
+                          ".*": {
+                            "type": [
+                              "string",
+                              "number",
+                              "boolean"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["traitSet", "policy"]
+              }
+            }
+          },
+          "required": ["default"],
+          "additionalProperties": false
+        },
+        "createRelated": {
+          "type": "object",
+          "description": "Custom managementPolicy responses for create related access contexts",
+          "properties": {
+            "default": {
+              "description": "The default policy unless an exception is specified",
+              "type": "object",
+              "patternProperties": {
+                ".*": {
+                  "description": "The trait's property values.",
+                  "type": "object",
+                  "patternProperties": {
+                    ".*": {
+                      "type": [
+                        "string",
+                        "number",
+                        "boolean"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "exceptions": {
+              "descriptions": "Custom policies that override the default",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "description": "A policy for a specific trait set, that must match the request exactly",
+                "properties": {
+                  "traitSet": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "policy": {
+                    "type": "object",
+                    "patternProperties": {
+                      ".*": {
+                        "description": "The trait's property values.",
+                        "type": "object",
+                        "patternProperties": {
+                          ".*": {
+                            "type": [
+                              "string",
+                              "number",
+                              "boolean"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["traitSet", "policy"]
+              }
+            }
+          },
+          "required": ["default"],
+          "additionalProperties": false
+        },
+        "managerDriven": {
+          "type": "object",
+          "description": "Custom managementPolicy responses for manager driven access contexts",
+          "properties": {
+            "default": {
+              "description": "The default policy unless an exception is specified",
+              "type": "object",
+              "patternProperties": {
+                ".*": {
+                  "description": "The trait's property values.",
+                  "type": "object",
+                  "patternProperties": {
+                    ".*": {
+                      "type": [
+                        "string",
+                        "number",
+                        "boolean"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "exceptions": {
+              "descriptions": "Custom policies that override the default",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "description": "A policy for a specific trait set, that must match the request exactly",
+                "properties": {
+                  "traitSet": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "policy": {
+                    "type": "object",
+                    "patternProperties": {
+                      ".*": {
+                        "description": "The trait's property values.",
+                        "type": "object",
+                        "patternProperties": {
+                          ".*": {
+                            "type": [
+                              "string",
+                              "number",
+                              "boolean"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "additionalProperties": false,
+                "required": ["traitSet", "policy"]
+              }
+            }
+          },
+          "required": ["default"],
+          "additionalProperties": false
         }
       },
       "required": ["read", "write"],
@@ -183,6 +378,13 @@
                           }
                         }
                       }
+                    }
+                  },
+                  "supported_access_modes": {
+                    "description": "Supported access modes for this entity",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
                     }
                   }
                 },

--- a/tests/resources/library_apiComplianceSuite.json
+++ b/tests/resources/library_apiComplianceSuite.json
@@ -6,6 +6,15 @@
     },
     "write": {
       "default": {}
+    },
+    "createRelated": {
+      "default": {}
+    },
+    "required": {
+      "default": {}
+    },
+    "managerDriven": {
+      "default": {}
     }
   },
   "entities": {
@@ -37,6 +46,17 @@
             "string": { "value": "resolved from 'another 𝓐𝓼𝓼𝓼𝓮𝔱' with a 📟" },
             "number": {}
           }
+        }
+      ]
+    },
+    "a manager driven asset": {
+      "versions": [
+        {
+          "traits": {
+            "string": { "value": "resolved value" },
+            "number": {}
+          },
+          "supported_access_modes": ["managerDriven"]
         }
       ]
     },

--- a/tests/resources/library_business_logic_suite_managementPolicy_custom.json
+++ b/tests/resources/library_business_logic_suite_managementPolicy_custom.json
@@ -22,6 +22,33 @@
           "policy": {"bal:test.SomePolicy": {}}
         }
       ]
+    },
+    "createRelated": {
+      "default": {},
+      "exceptions": [
+        {
+          "traitSet": ["a", "managed", "trait", "set"],
+          "policy": {"bal:test.SomePolicy": {}}
+        }
+      ]
+    },
+    "required": {
+      "default": {},
+      "exceptions": [
+        {
+          "traitSet": ["a", "managed", "trait", "set"],
+          "policy": {"bal:test.SomePolicy": {}}
+        }
+      ]
+    },
+    "managerDriven": {
+      "default": {},
+      "exceptions": [
+        {
+          "traitSet": ["a", "managed", "trait", "set"],
+          "policy": {"bal:test.SomePolicy": {}}
+        }
+      ]
     }
   },
   "entities": {}


### PR DESCRIPTION
Closes #98.

OpenAssetIO/OpenAssetIO#1209 added the `kRequired` and `kManagerDriven` access mode options for `managementPolicy` queries, i.e. the subset of required traits for publishing to succeed, and the subset of traits that the manager wants to dictate during publishing, respectively.

For consistency, the `kWrite` access mode of `resolve` was renamed to `kManagerDriven`.

So add support for these access modes in an extensible way, by making use of the `kAccessNames` string mapping to allow the JSON database to specialise on any access mode to `managementPolicy` in a consistent way.

Also add support for `resolve` to take any access mode, with a new JSON field `supported_access_modes`, which is an iterable of supported modes (i.e. `kRead` and/or `kManagerDriven`), and which defaults to only `kRead`.

This means we can have a JSON database entry for a "write only" entity, i.e. a "working reference" returned from a `preflight` API call, which should only be `resolve`d with `kManagerDriven` access mode. This then supports writing the example workflow in OpenAssetIO/OpenAssetIO-MediaCreation#75.

Currently, `preflight` simply returns the input reference as the "working reference". Ultimately, we will want the ability to customise that.

Interestingly, `register` _can_ return a different reference, in that it has the version identifier suffix appended (e.g. `?v=2`). This means for the purposes of exemplification in OpenAssetIO/OpenAssetIO-MediaCreation#75, we have everything we need.

