### PR TITLE
[CI] Retarget to OpenAssetIO release

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -29,21 +29,10 @@ jobs:
         with:
           python-version: "3.9"
 
-      - name: Download wheels from commit OpenAssetIO PR
-        uses: dawidd6/action-download-artifact@v3
-        with:
-          workflow: build-wheels.yml
-          workflow_conclusion: success
-          name: openassetio-wheels
-          repo: OpenAssetIO/OpenAssetIO
-          path: deps
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install setuptools wheel
-          # Use wheels from feature branch for intermediate testing
-          python -m pip install ./deps/openassetio-*cp39*-manylinux_*_x86_64.whl
 
       - name: Build wheels
         run: pip wheel --no-deps --wheel-dir wheelhouse .

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -13,19 +13,8 @@ jobs:
         with:
           python-version: 3.9
 
-      - name: Download wheels from commit OpenAssetIO PR
-        uses: dawidd6/action-download-artifact@v3
-        with:
-          workflow: build-wheels.yml
-          workflow_conclusion: success
-          name: openassetio-wheels
-          repo: OpenAssetIO/OpenAssetIO
-          path: deps
-
       - name: Install dependencies
         run: |
-          # Use wheels from feature branch for intermediate testing
-          python -m pip install ./deps/openassetio-*cp39*-manylinux_*_x86_64.whl
           python -m pip install -r tests/requirements.txt
           python -m pip install .
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,29 +10,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Constrain to single version to simplify install from wheels
-        os: ['ubuntu-latest']
-        python: ['3.7']
-        # os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
-        # python: ['3.7', '3.9', '3.10', '3.11']
+         os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
+         python: ['3.7', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v4
-
-      - name: Download wheels from OpenAssetIO main
-        uses: dawidd6/action-download-artifact@v3
-        with:
-          workflow: build-wheels.yml
-          workflow_conclusion: success
-          name: openassetio-wheels
-          repo: OpenAssetIO/OpenAssetIO
-          path: deps
-
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - run: |
-          # Use wheels from feature branch for intermediate testing
-          python -m pip install ./deps/openassetio-*cp37*-manylinux_*_x86_64.whl
           python -m pip install -r tests/requirements.txt
           python -m pip install .
           python -m pytest -v ./tests

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 Release Notes
 =============
 
-v1.0.0-alpha.xx (on release: reinstate `openassetio` dependency)
+v1.0.0-alpha.xx
 ---------------
 
 ### Breaking changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 name = "openassetio-manager-bal"
 version = "1.0.0a13"
 requires-python = ">=3.7"
-dependencies = ["openassetio-mediacreation>=1.0.0a7"]
+dependencies = ["openassetio>=1.0.0b2.rev0", "openassetio-mediacreation>=1.0.0a7"]
 
 authors = [
   { name = "Contributors to the OpenAssetIO project", email = "openassetio-discussion@lists.aswf.io" }


### PR DESCRIPTION
Now that OpenAssetIO v1.0.0-beta.2 is released, we can once again depend on the PyPI packages.