### PR TITLE
[Core] Fix resolve when trait has no properties

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,14 @@
 Release Notes
 =============
 
+v1.0.0-alpha.x
+---------------
+
+### Bug fixes
+
+- Fixed `resolve` to no longer imbue entity traits that have no
+  property values.
+
 v1.0.0-alpha.14
 ---------------
 

--- a/plugin/openassetio_manager_bal/BasicAssetLibraryInterface.py
+++ b/plugin/openassetio_manager_bal/BasicAssetLibraryInterface.py
@@ -278,7 +278,7 @@ class BasicAssetLibraryInterface(ManagerInterface):
                 result = TraitsData()
                 for trait in traitSet:
                     trait_data = entity.traits.get(trait)
-                    if trait_data is not None:
+                    if trait_data:
                         self.__add_trait_to_traits_data(trait, trait_data, result)
 
                 if VersionTrait.kId in traitSet:


### PR DESCRIPTION
Discovered whilst updating OpenAssetIO/OpenAssetIO-MediaCreation#69 after OpenAssetIO/OpenAssetIO#1217. The API docs for `resolve` say

> Only traits that are applicable to each entity, and for which the manager has data, will be imbued in the result.

However, if an entity in the JSON library has a trait as part of its trait set, but that trait has no properties (either because that trait has no associated properties, or because it's not set in the JSON), then it was imbued in the `TraitsData` regardless.