### PR TITLE
Support entity access policies

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -29,10 +29,21 @@ jobs:
         with:
           python-version: "3.9"
 
+      - name: Download wheels from commit OpenAssetIO main
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          workflow: build-wheels.yml
+          workflow_conclusion: success
+          name: openassetio-wheels
+          repo: OpenAssetIO/OpenAssetIO
+          path: deps
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install setuptools wheel
+          # Use wheels from feature branch for intermediate testing
+          python -m pip install ./deps/openassetio-*cp39*-manylinux_*_x86_64.whl
 
       - name: Build wheels
         run: pip wheel --no-deps --wheel-dir wheelhouse .

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -41,7 +41,7 @@ jobs:
           python -m pip install black
 
       - name: Check Python formatting
-        run: black --check .
+        run: black --check --diff .
 
   markdown-link-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -13,8 +13,19 @@ jobs:
         with:
           python-version: 3.9
 
+      - name: Download wheels from commit OpenAssetIO main
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          workflow: build-wheels.yml
+          workflow_conclusion: success
+          name: openassetio-wheels
+          repo: OpenAssetIO/OpenAssetIO
+          path: deps
+
       - name: Install dependencies
         run: |
+          # Use wheels from feature branch for intermediate testing
+          python -m pip install ./deps/openassetio-*cp39*-manylinux_*_x86_64.whl
           python -m pip install -r tests/requirements.txt
           python -m pip install .
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,14 +10,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-         os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
-         python: ['3.7', '3.9', '3.10', '3.11']
+        # Constrain to single version to simplify install from wheels
+        os: ['ubuntu-latest']
+        python: ['3.7']
+        # os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
+        # python: ['3.7', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v4
+
+      - name: Download wheels from OpenAssetIO main
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          workflow: build-wheels.yml
+          workflow_conclusion: success
+          name: openassetio-wheels
+          repo: OpenAssetIO/OpenAssetIO
+          path: deps
+
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - run: |
+          # Use wheels from feature branch for intermediate testing
+          python -m pip install ./deps/openassetio-*cp37*-manylinux_*_x86_64.whl
           python -m pip install -r tests/requirements.txt
           python -m pip install .
           python -m pytest -v ./tests

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,6 +16,12 @@ v1.0.0-alpha.x
   when publishing.
   [#90](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/90)
 
+- Added `"overrideByAccess"` option in the JSON DB entity entries,
+  allowing per access mode overrides of returned data, with `null`
+  signalling non-existence and empty dict `{}` signalling
+  inaccessibility.
+  [#90](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/90)
+
 ### Bug fixes
 
 - Fixed `resolve` to no longer imbue entity traits that have no

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,11 @@ v1.0.0-alpha.x
   of new API features.
   [#90](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/90)
 
+- Renamed the key for configuring per trait set `managementPolicy`
+  responses in the JSON database from `"exceptions"` to
+  `"overrideByTraitSet"`.
+  [#90](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/90)
+
 ### New features
 
 - Added validation during publishing against `managementPolicy` and the

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,12 @@ Release Notes
 v1.0.0-alpha.x
 ---------------
 
+### Breaking changes
+
+- Minimum OpenAssetIO version increased to v1.0.0-beta.3.0 to make use
+  of new API features.
+  [#90](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/90)
+
 ### Bug fixes
 
 - Fixed `resolve` to no longer imbue entity traits that have no

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,11 @@ v1.0.0-alpha.x
 - Fixed `resolve` to no longer imbue entity traits that have no
   property values.
 
+- Fixed to trigger a `kEntityResolutionError` result, rather than
+  `IndexError` exception, when querying an empty `"versions"` list in
+  the JSON database.
+  [#90](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/90)
+
 v1.0.0-alpha.14
 ---------------
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,12 @@ v1.0.0-alpha.x
   of new API features.
   [#90](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/90)
 
+### New features
+
+- Added validation against the `managementPolicy` entry in JSON database
+  when publishing.
+  [#90](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/90)
+
 ### Bug fixes
 
 - Fixed `resolve` to no longer imbue entity traits that have no

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,8 +12,8 @@ v1.0.0-alpha.x
 
 ### New features
 
-- Added validation against the `managementPolicy` entry in JSON database
-  when publishing.
+- Added validation during publishing against `managementPolicy` and the
+  `kWrite` entity trait set.
   [#90](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/90)
 
 - Added `"overrideByAccess"` option in the JSON DB entity entries,

--- a/plugin/openassetio_manager_bal/BasicAssetLibraryInterface.py
+++ b/plugin/openassetio_manager_bal/BasicAssetLibraryInterface.py
@@ -636,7 +636,7 @@ class BasicAssetLibraryInterface(ManagerInterface):
         elif isinstance(exc, bal.UnknownBALEntity):
             code = BatchElementError.ErrorCode.kEntityResolutionError
         elif isinstance(exc, bal.InvalidEntityVersion):
-            code = BatchElementError.ErrorCode.kMalformedEntityReference
+            code = BatchElementError.ErrorCode.kEntityResolutionError
         else:
             raise exc
 

--- a/plugin/openassetio_manager_bal/bal.py
+++ b/plugin/openassetio_manager_bal/bal.py
@@ -147,8 +147,8 @@ def management_policy(trait_set: Set[str], access: str, library: dict) -> dict:
     specific exception is provided in the library.
     """
     policies = library.get("managementPolicy", {}).get(access, {})
-    exceptions = policies.get("exceptions", [])
-    matching_exceptions = (e["policy"] for e in exceptions if set(e["traitSet"]) == trait_set)
+    overrides = policies.get("overrideByTraitSet", [])
+    matching_exceptions = (e["policy"] for e in overrides if set(e["traitSet"]) == trait_set)
     policy = next(matching_exceptions, policies.get("default"))
 
     if policy is None:

--- a/plugin/openassetio_manager_bal/bal.py
+++ b/plugin/openassetio_manager_bal/bal.py
@@ -230,6 +230,8 @@ def _entity_version_dict_and_tag(
     """
     entity_dict = _ensure_library_entity_dict(entity_info, library)
     versions_list = entity_dict["versions"]
+    if not versions_list:
+        return None, None
 
     if entity_info.version:
         version_index = entity_info.version - 1
@@ -349,5 +351,5 @@ class InvalidEntityVersion(RuntimeError):
 
     def __init__(self, entity_info: EntityInfo):
         super().__init__(
-            f"Entity '{entity_info.name}' does not have " f"a version {entity_info.version}"
+            f"Entity '{entity_info.name}' does not have a version {entity_info.version or 1}"
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 name = "openassetio-manager-bal"
 version = "1.0.0a14"
 requires-python = ">=3.7"
-dependencies = ["openassetio>=1.0.0b2.rev0", "openassetio-mediacreation>=1.0.0a7"]
+dependencies = ["openassetio-mediacreation>=1.0.0a7"]
 
 authors = [
   { name = "Contributors to the OpenAssetIO project", email = "openassetio-discussion@lists.aswf.io" }

--- a/schema.json
+++ b/schema.json
@@ -44,7 +44,7 @@
                 }
               }
             },
-            "exceptions": {
+            "overrideByTraitSet": {
               "descriptions": "Custom policies that override the default",
               "type": "array",
               "items": {
@@ -109,7 +109,7 @@
                 }
               }
             },
-            "exceptions": {
+            "overrideByTraitSet": {
               "descriptions": "Custom policies that override the default",
               "type": "array",
               "items": {
@@ -174,7 +174,7 @@
                 }
               }
             },
-            "exceptions": {
+            "overrideByTraitSet": {
               "descriptions": "Custom policies that override the default",
               "type": "array",
               "items": {
@@ -239,7 +239,7 @@
                 }
               }
             },
-            "exceptions": {
+            "overrideByTraitSet": {
               "descriptions": "Custom policies that override the default",
               "type": "array",
               "items": {
@@ -304,7 +304,7 @@
                 }
               }
             },
-            "exceptions": {
+            "overrideByTraitSet": {
               "descriptions": "Custom policies that override the default",
               "type": "array",
               "items": {

--- a/schema.json
+++ b/schema.json
@@ -360,7 +360,7 @@
             "versions": {
               "type": "array",
               "description": "The versions array holds the actual data, the array index is used as the version number.",
-              "minItems": 1,
+              "minItems": 0,
               "items": {
                 "type": "object",
                 "description": "The data for any given entity.",

--- a/schema.json
+++ b/schema.json
@@ -379,17 +379,42 @@
                         }
                       }
                     }
-                  },
-                  "supported_access_modes": {
-                    "description": "Supported access modes for this entity",
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
                   }
                 },
                 "required": ["traits"],
                 "additionalProperties": false
+              }
+            },
+            "overrideByAccess": {
+              "type": "object",
+              "description": "Override of version data per access mode.",
+              "patternProperties": {
+                ".*": {
+                  "type": ["object", "null"],
+                  "description": "Mapping of access mode to entity version data.",
+                  "properties": {
+                    "traits": {
+                      "description": "Traits and their associated properties for the entity.",
+                      "type": "object",
+                      "patternProperties": {
+                        ".*": {
+                          "description": "The trait's property values.",
+                          "type": "object",
+                          "patternProperties": {
+                            ".*": {
+                              "type": [
+                                "string",
+                                "number",
+                                "boolean"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                }
               }
             },
             "relations": {

--- a/tests/bal_business_logic_suite.py
+++ b/tests/bal_business_logic_suite.py
@@ -519,6 +519,22 @@ class Test_resolve(FixtureAugmentedTestCase):
 
         self.assertEqual(actual_results, expected_results)
 
+    def test_when_entity_has_no_versions_then_EntityResolutionError(self):
+        expected = BatchElementError(
+            BatchElementError.ErrorCode.kEntityResolutionError,
+            "Entity 'an asset with no versions' does not have a version 1",
+        )
+
+        actual = self._manager.resolve(
+            self._manager.createEntityReference("bal:///an asset with no versions"),
+            set(),
+            ResolveAccess.kRead,
+            self.createTestContext(),
+            self._manager.BatchElementErrorPolicyTag.kVariant,
+        )
+
+        self.assertEqual(actual, expected)
+
     def test_when_unsupported_access_then_kEntityAccessError_returned(self):
         entity_reference_str = next(iter(self.__entities.keys()))
         entity_references = [self._manager.createEntityReference(entity_reference_str)]

--- a/tests/bal_business_logic_suite.py
+++ b/tests/bal_business_logic_suite.py
@@ -950,6 +950,43 @@ class Test_preflight(FixtureAugmentedTestCase):
 
         self.assertEqual(actual_result, expected_result)
 
+    def test_when_required_traits_for_entity_missing_then_InvalidTraitSet_returned(self):
+        entity_ref = self._manager.createEntityReference(
+            "bal:///an asset with required traits for publish"
+        )
+        traits_data = TraitsData({"string"})
+        expected_result = BatchElementError(
+            BatchElementError.ErrorCode.kInvalidTraitSet,
+            "Publishing to this entity requires traits that are missing from the input",
+        )
+
+        actual_result = self._manager.preflight(
+            entity_ref,
+            traits_data,
+            PublishingAccess.kWrite,
+            self.createTestContext(),
+            self._manager.BatchElementErrorPolicyTag.kVariant,
+        )
+
+        self.assertEqual(actual_result, expected_result)
+
+    def test_when_read_only_entity_then_EntityAccessError_returned(self):
+        entity_ref = self._manager.createEntityReference("bal:///a read only asset")
+        traits_data = TraitsData({"string"})
+        expected_result = BatchElementError(
+            BatchElementError.ErrorCode.kEntityAccessError,
+            "Entity 'a read only asset' is inaccessible for write",
+        )
+
+        actual_result = self._manager.preflight(
+            entity_ref,
+            traits_data,
+            PublishingAccess.kWrite,
+            self.createTestContext(),
+            self._manager.BatchElementErrorPolicyTag.kVariant,
+        )
+
+        self.assertEqual(actual_result, expected_result)
 
 
 class Test_register(FixtureAugmentedTestCase):
@@ -1081,6 +1118,44 @@ class Test_register(FixtureAugmentedTestCase):
         expected_result = BatchElementError(
             BatchElementError.ErrorCode.kInvalidTraitSet,
             "Publishing is not supported for the given trait set",
+        )
+
+        actual_result = self._manager.register(
+            entity_ref,
+            traits_data,
+            PublishingAccess.kWrite,
+            self.createTestContext(),
+            self._manager.BatchElementErrorPolicyTag.kVariant,
+        )
+
+        self.assertEqual(actual_result, expected_result)
+
+    def test_when_required_traits_for_entity_missing_then_InvalidTraitSet_returned(self):
+        entity_ref = self._manager.createEntityReference(
+            "bal:///an asset with required traits for publish"
+        )
+        traits_data = TraitsData({"string"})
+        expected_result = BatchElementError(
+            BatchElementError.ErrorCode.kInvalidTraitSet,
+            "Publishing to this entity requires traits that are missing from the input",
+        )
+
+        actual_result = self._manager.register(
+            entity_ref,
+            traits_data,
+            PublishingAccess.kWrite,
+            self.createTestContext(),
+            self._manager.BatchElementErrorPolicyTag.kVariant,
+        )
+
+        self.assertEqual(actual_result, expected_result)
+
+    def test_when_read_only_entity_then_EntityAccessError_returned(self):
+        entity_ref = self._manager.createEntityReference("bal:///a read only asset")
+        traits_data = TraitsData({"string"})
+        expected_result = BatchElementError(
+            BatchElementError.ErrorCode.kEntityAccessError,
+            "Entity 'a read only asset' is inaccessible for write",
         )
 
         actual_result = self._manager.register(

--- a/tests/bal_business_logic_suite.py
+++ b/tests/bal_business_logic_suite.py
@@ -880,6 +880,25 @@ class Test_preflight(FixtureAugmentedTestCase):
         for ref in result_references:
             self.assertFalse("v=" in ref.toString())
 
+    def test_when_unsupported_trait_set_then_InvalidTraitSet_returned(self):
+        entity_ref = self._manager.createEntityReference("bal:///new")
+        traits_data = TraitsData({"an", "ignored", "trait", "set"})
+        expected_result = BatchElementError(
+            BatchElementError.ErrorCode.kInvalidTraitSet,
+            "Publishing is not supported for the given trait set",
+        )
+
+        actual_result = self._manager.preflight(
+            entity_ref,
+            traits_data,
+            PublishingAccess.kWrite,
+            self.createTestContext(),
+            self._manager.BatchElementErrorPolicyTag.kVariant,
+        )
+
+        self.assertEqual(actual_result, expected_result)
+
+
 
 class Test_register(FixtureAugmentedTestCase):
     def test_when_ref_is_new_then_entity_created_with_versioned_reference(self):
@@ -1003,6 +1022,24 @@ class Test_register(FixtureAugmentedTestCase):
         )
 
         return published_refs[0]
+
+    def test_when_unsupported_trait_set_then_InvalidTraitSet_returned(self):
+        entity_ref = self._manager.createEntityReference("bal:///new")
+        traits_data = TraitsData({"an", "ignored", "trait", "set"})
+        expected_result = BatchElementError(
+            BatchElementError.ErrorCode.kInvalidTraitSet,
+            "Publishing is not supported for the given trait set",
+        )
+
+        actual_result = self._manager.register(
+            entity_ref,
+            traits_data,
+            PublishingAccess.kWrite,
+            self.createTestContext(),
+            self._manager.BatchElementErrorPolicyTag.kVariant,
+        )
+
+        self.assertEqual(actual_result, expected_result)
 
 
 class Test_getWithRelationship_versions(GetWithRelationshipTestCase):

--- a/tests/bal_business_logic_suite.py
+++ b/tests/bal_business_logic_suite.py
@@ -467,6 +467,35 @@ class Test_entityTraits(FixtureAugmentedTestCase):
 
         self.assertSetEqual(read_result, write_result | {VersionTrait.kId})
 
+    def test_when_explicit_write_traits_then_those_traits_returned(self):
+        ref = self._manager.createEntityReference(
+            "bal:///an asset with required traits for publish"
+        )
+        context = self.createTestContext()
+
+        read_traits = self._manager.entityTraits(ref, EntityTraitsAccess.kRead, context)
+        write_traits = self._manager.entityTraits(ref, EntityTraitsAccess.kWrite, context)
+
+        self.assertSetEqual(read_traits, {"string", "number", VersionTrait.kId})
+        self.assertSetEqual(write_traits, {"number"})
+
+    def test_when_read_only_entity_then_EntityAccessError_returned(self):
+        ref = self._manager.createEntityReference("bal:///a read only asset")
+        expected_result = BatchElementError(
+            BatchElementError.ErrorCode.kEntityAccessError,
+            "Entity 'a read only asset' is inaccessible for write",
+        )
+        context = self.createTestContext()
+
+        actual_result = self._manager.entityTraits(
+            ref,
+            EntityTraitsAccess.kWrite,
+            context,
+            self._manager.BatchElementErrorPolicyTag.kVariant,
+        )
+
+        self.assertEqual(actual_result, expected_result)
+
 
 class Test_resolve(FixtureAugmentedTestCase):
     """
@@ -535,39 +564,28 @@ class Test_resolve(FixtureAugmentedTestCase):
 
         self.assertEqual(actual, expected)
 
-    def test_when_unsupported_access_then_kEntityAccessError_returned(self):
-        entity_reference_str = next(iter(self.__entities.keys()))
-        entity_references = [self._manager.createEntityReference(entity_reference_str)]
-        trait_set = {"string", "number", "test-data"}
-
-        expected = [
-            BatchElementError(
-                BatchElementError.ErrorCode.kEntityAccessError,
-                "Unsupported access mode for resolve",
-            )
-        ]
-
+    def test_when_implicitly_supported_access_then_can_resolve_access(self):
+        trait_set = {"string", "wont-resolve"}
+        expected = TraitsData({"string"})
+        # Kludge to satisfy black formatting difference at exactly 99
+        # chars on CI vs. local. Unicode shenanigans?
+        expected_property_value = "resolved from 'anAsset⭐︎' version 2 using 📠"
+        expected.setTraitProperty("string", "value", expected_property_value)
         context = self.createTestContext()
-        actual = [None]
 
-        self._manager.resolve(
-            entity_references,
+        actual = self._manager.resolve(
+            self._manager.createEntityReference("bal:///anAsset⭐︎"),
             trait_set,
             ResolveAccess.kManagerDriven,
             context,
-            lambda idx, _: self.fail(
-                f"Unexpected success for '{entity_references[idx].toString()}'"
-            ),
-            # pylint: disable=cell-var-from-loop
-            lambda idx, err: operator.setitem(actual, idx, err),
         )
 
-        self.assertListEqual(actual, expected)
+        self.assertEqual(actual, expected)
 
     def test_when_explicitly_supported_access_then_can_resolve_supported_access(self):
         trait_set = {"string", "number", "test-data"}
         expected = TraitsData({"string"})
-        expected.setTraitProperty("string", "value", "resolved value")
+        expected.setTraitProperty("string", "value", "manager driven value")
         context = self.createTestContext()
 
         actual = self._manager.resolve(
@@ -579,11 +597,11 @@ class Test_resolve(FixtureAugmentedTestCase):
 
         self.assertEqual(actual, expected)
 
-    def test_when_explicitly_supported_access_then_cannot_resolve_unsupported_access(self):
+    def test_when_access_null_then_EntityResolutionError(self):
         trait_set = {"string", "number", "test-data"}
         expected = BatchElementError(
-            BatchElementError.ErrorCode.kEntityAccessError,
-            "Unsupported access mode for resolve",
+            BatchElementError.ErrorCode.kEntityResolutionError,
+            "Entity 'a manager driven asset' does not have a version 1",
         )
         context = self.createTestContext()
 
@@ -591,6 +609,24 @@ class Test_resolve(FixtureAugmentedTestCase):
             self._manager.createEntityReference("bal:///a manager driven asset"),
             trait_set,
             ResolveAccess.kRead,
+            context,
+            Manager.BatchElementErrorPolicyTag.kVariant,
+        )
+
+        self.assertEqual(actual, expected)
+
+    def test_when_access_blank_then_EntityAccessError(self):
+        trait_set = {"string", "number", "test-data"}
+        expected = BatchElementError(
+            BatchElementError.ErrorCode.kEntityAccessError,
+            "Entity 'a read only asset' is inaccessible for managerDriven",
+        )
+        context = self.createTestContext()
+
+        actual = self._manager.resolve(
+            self._manager.createEntityReference("bal:///a read only asset"),
+            trait_set,
+            ResolveAccess.kManagerDriven,
             context,
             Manager.BatchElementErrorPolicyTag.kVariant,
         )

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -169,9 +169,9 @@ fixtures = {
         "shared": {
             "a_reference_to_a_readable_entity": f"bal:///{an_existing_entity_name}",
             "a_set_of_valid_traits": {"string", "number"},
-            "a_reference_to_a_readonly_entity": f"bal:///{an_existing_entity_name}",
+            "a_reference_to_a_readonly_entity": "bal:///a read only asset",
             "the_error_string_for_a_reference_to_a_readonly_entity": (
-                "Unsupported access mode for resolve"
+                "Entity 'a read only asset' is inaccessible for managerDriven"
             ),
             "a_reference_to_a_missing_entity": MISSING_REF,
             "the_error_string_for_a_reference_to_a_missing_entity": ERROR_MSG_MISSING_ENTITY,

--- a/tests/resources/library_apiComplianceSuite.json
+++ b/tests/resources/library_apiComplianceSuite.json
@@ -6,7 +6,7 @@
     },
     "write": {
       "default": {"bal:test.SomePolicy":  {}},
-      "exceptions": [
+      "overrideByTraitSet": [
         {
           "traitSet": ["an", "ignored", "trait", "set"],
           "policy": {}

--- a/tests/resources/library_apiComplianceSuite.json
+++ b/tests/resources/library_apiComplianceSuite.json
@@ -58,16 +58,53 @@
     "an asset with no versions": {
       "versions": []
     },
+    "a read only asset": {
+      "versions": [
+        {
+          "traits": {
+            "string": {"value": "resolved value"}
+          }
+        }
+      ],
+      "overrideByAccess": {
+        "managerDriven": {},
+        "write": {}
+      }
+    },
     "a manager driven asset": {
       "versions": [
         {
           "traits": {
-            "string": { "value": "resolved value" },
-            "number": {}
-          },
-          "supported_access_modes": ["managerDriven"]
+            "string": {"value": "impossible to resolve - see 'overrideByAccess'"},
+            "number": {"value": 123}
+          }
         }
-      ]
+      ],
+      "overrideByAccess": {
+        "read": null,
+        "managerDriven": {
+          "traits": {
+            "string": {"value": "manager driven value"}
+          }
+        }
+      }
+    },
+    "an asset with required traits for publish": {
+      "versions": [
+        {
+          "traits": {
+            "string": {"value": "resolved value"},
+            "number": {"value": 123}
+          }
+        }
+      ],
+      "overrideByAccess": {
+        "write": {
+          "traits": {
+            "number": {}
+          }
+        }
+      }
     },
     "entity/original": {
       "versions": [{"traits": {}}],

--- a/tests/resources/library_apiComplianceSuite.json
+++ b/tests/resources/library_apiComplianceSuite.json
@@ -55,6 +55,9 @@
         }
       ]
     },
+    "an asset with no versions": {
+      "versions": []
+    },
     "a manager driven asset": {
       "versions": [
         {

--- a/tests/resources/library_apiComplianceSuite.json
+++ b/tests/resources/library_apiComplianceSuite.json
@@ -5,7 +5,13 @@
       "default": {}
     },
     "write": {
-      "default": {}
+      "default": {"bal:test.SomePolicy":  {}},
+      "exceptions": [
+        {
+          "traitSet": ["an", "ignored", "trait", "set"],
+          "policy": {}
+        }
+      ]
     },
     "createRelated": {
       "default": {}

--- a/tests/resources/library_business_logic_suite_managementPolicy_custom.json
+++ b/tests/resources/library_business_logic_suite_managementPolicy_custom.json
@@ -3,7 +3,7 @@
   "managementPolicy": {
     "read": {
       "default": {"bal:test.SomePolicy": {"exclusive": true}},
-      "exceptions": [
+      "overrideByTraitSet": [
         {
           "traitSet": ["an", "ignored", "trait", "set"],
           "policy": {}
@@ -16,7 +16,7 @@
     },
     "write": {
       "default": {},
-      "exceptions": [
+      "overrideByTraitSet": [
         {
           "traitSet": ["a", "managed", "trait", "set"],
           "policy": {"bal:test.SomePolicy": {}}
@@ -25,7 +25,7 @@
     },
     "createRelated": {
       "default": {},
-      "exceptions": [
+      "overrideByTraitSet": [
         {
           "traitSet": ["a", "managed", "trait", "set"],
           "policy": {"bal:test.SomePolicy": {}}
@@ -34,7 +34,7 @@
     },
     "required": {
       "default": {},
-      "exceptions": [
+      "overrideByTraitSet": [
         {
           "traitSet": ["a", "managed", "trait", "set"],
           "policy": {"bal:test.SomePolicy": {}}
@@ -43,7 +43,7 @@
     },
     "managerDriven": {
       "default": {},
-      "exceptions": [
+      "overrideByTraitSet": [
         {
           "traitSet": ["a", "managed", "trait", "set"],
           "policy": {"bal:test.SomePolicy": {}}


### PR DESCRIPTION
Closes #90 #92. 

Error during publishing (`preflight` and `register`) if the provided trait set is incompatible with `managementPolicy` or `entityTraits` (with `kWrite` access mode).

Add access mode to `EntityInfo`, for use in JSON DB queries. Default to ignoring access mode and returning the same data (from the entity `"versions"` list) for all access modes.

Add new `"exceptions"` option alongside an entity `"versions"` list in the JSON database. The `"exceptions"` object is a mapping of (stringified) access mode to entity data, overriding lookup in the `"versions"` list. 

In the new `"exceptions"` mapping, use the special value of `null` to mean the entity doesn't 'exist' for that access mode. Use the special value of empty dict `{}` to mean the entity exists but is inaccessible for that access mode.

With this mechanism in place, we can simulate read-only and write-only entities, and customise the returned trait sets for read and write access patterns, which then feeds into the aforementioned additional publishing validation.

## Reviewer notes

CI is retargeted to use OpenAssetIO `main`.  This is only necessary because the new convenience signatures for `entityTraits` are used in the tests. I'm happy to change this to use the callback-based signatures, so we don't have to target `main`, if desired.