### PR TITLE
[Core] Don't %-decode file URLs from DB

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
+        os: ['windows-latest', 'ubuntu-latest', 'macos-13']
         python: ['3.7', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v4

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,16 @@
 Release Notes
 =============
 
+v1.0.0-alpha.x
+---------------
+
+### Bug fixes
+
+- Fixed normalisation of `file://` URLs from the JSON database such that
+  they are no longer percent decoded before being passed on to the host.
+  [#109](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/109)
+
+
 v1.0.0-alpha.15
 ---------------
 

--- a/tests/resources/library_business_logic_suite_var_expansion.json
+++ b/tests/resources/library_business_logic_suite_var_expansion.json
@@ -19,8 +19,12 @@
               "bal_library_dir": "Library is in $bal_library_dir",
               "bal_library_path": "Library is ${bal_library_path}",
               "bal_library_dir_url": "Library is in ${bal_library_dir_url}",
-              "relative_to_bal_library_dir_url": "${bal_library_dir_url}/../aboveFile.txt",
-              "relative_to_bal_library_dir": "${bal_library_dir}/../aboveFile.txt",
+              "a_file_prefixed_non_url": "file:\\",
+              "a_raw_posix_file_url": "file:///mnt/per%2520cent",
+              "a_raw_windows_drive_file_url": "file:///C:/per%2520cent",
+              "a_raw_windows_unc_file_url": "file://hostname/sharename/per%2520cent",
+              "relative_to_bal_library_dir_url": "${bal_library_dir_url}/../above%2520File.txt",
+              "relative_to_bal_library_dir": "${bal_library_dir}/../above%20File.txt",
               "aLibraryVar": "Value $aLibraryVar"
             }
           }


### PR DESCRIPTION
Closes #109. We should not be percent-decoding URLs fetched from the JSON DB before passing to the host, since other functions that consume the returned URL will most likely expect the URL to be percent-encoded.

In order to allow for upward traversals to be used in `file://` URLs in the DB (in particular, useful for e.g.
`${bal_library_dir_url}/../path/to/file`) we needed to parse the URL to treat as a path, resolve the upward traversals (since they are invalid in URLs according to `FileUrlPathConverter`), then reconstruct the URL. Unfortunately in doing this we also percent-decoded the URL and didn't re-encode it.

Passing the decoded URL to `FileUrlPathConverter.pathFromUrl` would then do a second round of percent-decoding, possibly decoding what should have been left as a %-sign.

So re-write the `file://` normalisation logic to avoid having to deal with percent decoding at all.