### PR TITLE
Configurable `hasCapability` responses

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,11 @@ v1.0.0-alpha.x
 
 ### New features
 
+- Added support for configuring the result of `hasCapability(...)`
+  queries. This allows hosts to test their logic when dealing with
+  managers that have limited capability.
+  [#84](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/84)
+
 - Added support for `OPENASSETIO_BAL_IDENTIFIER` environment variable,
   for overriding the identifier advertised by the BAL plugin/manager.
   [#116](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/pull/116)

--- a/schema.json
+++ b/schema.json
@@ -5,6 +5,15 @@
   "description": "The data store that backs an instance of the BAL manager",
   "type": "object",
   "properties": {
+    "capabilities": {
+      "description": "List of capabilities that BAL should advertise",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "description": "The name of a capability, as defined in ManagerInterface.kCapabilityNames"
+      },
+      "additionalProperties": false
+    },
     "variables": {
       "description": "Arbitrary variables to be substituted in string trait properties",
       "type": "object",

--- a/tests/resources/library_business_logic_suite_capabilities_all.json
+++ b/tests/resources/library_business_logic_suite_capabilities_all.json
@@ -1,0 +1,14 @@
+{
+  "capabilities": [
+    "entityReferenceIdentification",
+    "managementPolicyQueries",
+    "statefulContexts",
+    "customTerminology",
+    "resolution",
+    "publishing",
+    "relationshipQueries",
+    "existenceQueries",
+    "defaultEntityReferences",
+    "entityTraitIntrospection"
+  ]
+}

--- a/tests/resources/library_business_logic_suite_capabilities_minimal.json
+++ b/tests/resources/library_business_logic_suite_capabilities_minimal.json
@@ -1,0 +1,7 @@
+{
+  "capabilities": [
+    "entityReferenceIdentification",
+    "managementPolicyQueries",
+    "entityTraitIntrospection"
+  ]
+}

--- a/tests/resources/library_business_logic_suite_capabilities_none.json
+++ b/tests/resources/library_business_logic_suite_capabilities_none.json
@@ -1,0 +1,3 @@
+{
+  "capabilities": []
+}


### PR DESCRIPTION
Closes #84. Host applications must be able to tolerate manager plugins that do not support the full suite of (optional) capabilities that a manager may implement. However, there was no way for hosts to use BAL to test their logic for dealing with different combinations of capabilities.

In addition, configurable capabilities are required to enable e2e testing of the capability-based routing used by the upcoming hybrid plugin system (see OpenAssetIO/OpenAssetIO#1202).

So add a simple way to override the default set of capabilities reported by BAL, by adding an optional "capabilities" list element to the library, where each element is a stringified capability, as defined in `kCapabilityNames`. Presence of a capability in this list indicates that it is supported. If the list is not found, then the default (i.e. true) set of capabilities is used.

Short-circuit methods where the capability is unsupported. Instead, call the base class (which will raise an error).

This logic is similar to that used in the SimpleCppManager (see OpenAssetIO/OpenAssetIO#1324).

Also see https://github.com/OpenAssetIO/OpenAssetIO-MediaCreation/pull/99 for context.