### PR TITLE
Allow `initialize` with unrecognized settings

### DIFF
--- a/plugin/openassetio_manager_bal/BasicAssetLibraryInterface.py
+++ b/plugin/openassetio_manager_bal/BasicAssetLibraryInterface.py
@@ -688,8 +688,6 @@ class BasicAssetLibraryInterface(ManagerInterface):
         Parses the supplied settings dict, raising if there are any
         unrecognized keys present.
         """
-        defaults = BasicAssetLibraryInterface.__make_default_settings()
-
         if SETTINGS_KEY_LIBRARY_PATH in settings:
             if not isinstance(settings[SETTINGS_KEY_LIBRARY_PATH], str):
                 raise ValueError(f"{SETTINGS_KEY_LIBRARY_PATH} must be a str")
@@ -714,10 +712,6 @@ class BasicAssetLibraryInterface(ManagerInterface):
                     f"{SETTINGS_KEY_ENTITY_REFERENCE_URL_SCHEME} '{scheme}' must only consist of "
                     "legal URL scheme characters (a-z, A-Z, 0-9, -)"
                 )
-
-        for key in settings:
-            if key not in defaults:
-                raise KeyError(f"Unknown setting '{key}'")
 
 
 class BALEntityReferencePagerInterface(EntityReferencePagerInterface):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -105,12 +105,6 @@ fixtures = {
                 "entity_reference_url_scheme": "thingy",
             }
         },
-        "test_when_settings_have_invalid_keys_then_all_settings_unchanged": {
-            "some_settings_with_new_values_and_invalid_keys": {"library_path": "", "cat": True}
-        },
-        "test_when_settings_have_invalid_keys_then_raises_KeyError": {
-            "some_settings_with_new_values_and_invalid_keys": {"library_path": "", "cat": True}
-        },
         "test_when_settings_have_subset_of_keys_then_other_settings_unchanged": {
             "some_settings_with_a_subset_of_keys": {"simulated_query_latency_ms": 2}
         },


### PR DESCRIPTION
Part of OpenAssetIO/OpenAssetIO#1202.

Disallowing unrecognized settings almost certainly precludes using BAL as part of a hybrid plugin, since it is likely the other constituent plugins will have different settings keys, and the hybrid plugin system will pass the same settings dict to all child plugins.

As a result, the corresponding test in the API compliance suite will be removed from the core OpenAssetIO distribution, effectively relaxing the restriction that unrecognized keys should trigger an exception.

So remove the check for unknown settings keys, and corresponding API compliance suite fixtures.