### PR TITLE
[Build] Bump MediaCreation to 1.0.0-alpha.9

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,11 @@ v1.0.0-alpha.x
   of new API features.
   [#84](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/84)
 
+- Minimum OpenAssetIO-MediaCreation version increased to v1.0.0-alpha.9
+  for compatibility with the latest OpenAssetIO. See
+  [OpenAssetIO#1311](https://github.com/OpenAssetIO/OpenAssetIO/issues/1311).
+  [#90](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/90)
+
 ### New features
 
 - Added support for configuring the result of `hasCapability(...)`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 name = "openassetio-manager-bal"
 version = "1.0.0a16"
 requires-python = ">=3.7"
-dependencies = ["openassetio>=1.0.0b2.rev2", "openassetio-mediacreation>=1.0.0a7"]
+dependencies = ["openassetio>=1.0.0b2.rev2", "openassetio-mediacreation>=1.0.0a9"]
 
 authors = [
   { name = "Contributors to the OpenAssetIO project", email = "openassetio-discussion@lists.aswf.io" }


### PR DESCRIPTION
Part of OpenAssetIO/OpenAssetIO#1311. Deprecated aliases have been removed from the latest OpenAssetIO, but the version of MediaCreation that was pinned in `pyproject.toml` still used them.

So bump the version of MediaCreation to the latest.