### PR TITLE
[Build] Bump OpenAssetIO to 1.0.0-beta.2.2

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,12 @@ Release Notes
 v1.0.0-alpha.x
 ---------------
 
+### Breaking changes
+
+- Minimum OpenAssetIO version increased to v1.0.0-beta.2.2 to make use
+  of new API features.
+  [#84](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/84)
+
 ### New features
 
 - Added support for configuring the result of `hasCapability(...)`
@@ -23,7 +29,6 @@ v1.0.0-alpha.16
 - Fixed normalisation of `file://` URLs from the JSON database such that
   they are no longer percent decoded before being passed on to the host.
   [#109](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/109)
-
 
 v1.0.0-alpha.15
 ---------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 name = "openassetio-manager-bal"
 version = "1.0.0a16"
 requires-python = ">=3.7"
-dependencies = ["openassetio>=1.0.0b2.rev0", "openassetio-mediacreation>=1.0.0a7"]
+dependencies = ["openassetio>=1.0.0b2.rev2", "openassetio-mediacreation>=1.0.0a7"]
 
 authors = [
   { name = "Contributors to the OpenAssetIO project", email = "openassetio-discussion@lists.aswf.io" }


### PR DESCRIPTION
Discovered during OpenAssetIO/OpenAssetIO#1311.

Since #84, BAL's tests make use of the newer `getWithRelationship` signatures and so fail if OpenAssetIO 1.0.0-beta.2.1 or earlier is installed.

This isn't an incompatibility in BAL itself, just its tests. We could either:
* Rewrite the tests to use the older API.
* Bump the minimum supported version of OpenAssetIO
* Ignore the failure, since it's only tests.

Ignoring the test failure is potentially dangerous, in case the expected failure is masking a real issue.

Rewriting the tests would be the best option, but requires development effort. Given that we're still in beta, the low-effort choice of bumping the minimum OpenAssetIO version seems the best pragmatic option.