### PR TITLE
Default to CY24 and drop support for CY22

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   build_wheels:
     name: Build wheel
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -3,7 +3,7 @@ on: pull_request
 
 jobs:
   pylint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Pylint
     steps:
       - uses: actions/checkout@v4
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |
@@ -26,7 +26,7 @@ jobs:
           pylint-paths: "plugin tests"
 
   black:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Python formatting
     steps:
       - uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |
@@ -44,7 +44,7 @@ jobs:
         run: black --check --diff .
 
   markdown-link-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   publish_testpypi:
     name: Publish distribution 📦 to TestPyPI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Download wheels from commit ${{ github.sha }}
         uses: dawidd6/action-download-artifact@v6
@@ -38,7 +38,7 @@ jobs:
   publish_pypi:
     name: Publish distribution 📦 to PyPI
     needs: publish_testpypi
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Download wheels from commit ${{ github.sha }}
         uses: dawidd6/action-download-artifact@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['windows-latest', 'ubuntu-latest', 'macos-13']
-        python: ['3.7', '3.9', '3.10', '3.11']
+        os: ['windows-2022', 'ubuntu-22.04', 'macos-13']
+        python: ['3.10', '3.11']
     steps:
       - uses: actions/checkout@v4
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,10 @@ v1.0.0-alpha.x
 
 ### Breaking changes
 
+- Removed support for VFX Reference Platform CY22 or lower. This means
+  Python 3.7 and 3.9 builds are no longer tested or published.
+  [OpenAssetIO#1351](https://github.com/OpenAssetIO/OpenAssetIO/issues/1351)
+
 - Minimum OpenAssetIO version increased to v1.0.0-beta.2.2 to make use
   of new API features.
   [#84](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/84)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "openassetio-manager-bal"
 version = "1.0.0a16"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 dependencies = ["openassetio>=1.0.0b2.rev2", "openassetio-mediacreation>=1.0.0a9"]
 
 authors = [


### PR DESCRIPTION
Part of OpenAssetIO/OpenAssetIO#1351. Use CI runner and Python version the best matches VFX Reference Platform CY24. Hence drop support for CY22.