### PR TITLE
Support `defaultEntityReference`

### DIFF
--- a/plugin/openassetio_manager_bal/bal.py
+++ b/plugin/openassetio_manager_bal/bal.py
@@ -112,6 +112,19 @@ def exists(entity_info: EntityInfo, library: dict) -> bool:
     return True
 
 
+def default_entity(trait_set: Set[str], access: str, library: dict) -> str:
+    """
+    Retrieves the default entity for the supplied trait set and access
+    mode, if one exists in the library, otherwise raises an exception.
+    """
+    default_entities_for_access = library.get("defaultEntities", {}).get(access, [])
+    # Find the first default entity that matches the trait set
+    for default_entity_for_trait_set in default_entities_for_access:
+        if set(default_entity_for_trait_set["traits"]) == trait_set:
+            return default_entity_for_trait_set["entity"]
+    raise UnknownTraitSet(trait_set)
+
+
 def entity(entity_info: EntityInfo, library: dict) -> Entity:
     """
     Retrieves the Entity data addressed by the supplied EntityInfo
@@ -412,3 +425,12 @@ class InaccessibleEntity(RuntimeError):
 
     def __init__(self, entity_info: EntityInfo):
         super().__init__(f"Entity '{entity_info.name}' is inaccessible for {entity_info.access}")
+
+
+class UnknownTraitSet(RuntimeError):
+    """
+    An exception raised when BAL doesn't understand a given trait set.
+    """
+
+    def __init__(self, trait_set: Set[str]):
+        super().__init__(f"Unknown trait set {trait_set}")

--- a/schema.json
+++ b/schema.json
@@ -359,6 +359,75 @@
       "required": ["read", "write"],
       "additionalProperties": false
     },
+    "defaultEntities": {
+      "description": "A mapping of intended access and trait set to appropriate default entity",
+      "type": "object",
+      "properties": {
+        "read": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "traits": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "entity": {
+                "type": ["string", "null"]
+              }
+            },
+            "required": [
+              "traits",
+              "entity"
+            ]
+          }
+        },
+        "write": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "traits": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "entity": {
+                "type": ["string", "null"]
+              }
+            },
+            "required": [
+              "traits",
+              "entity"
+            ]
+          }
+        },
+        "createRelated": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "traits": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "entity": {
+                "type": ["string", "null"]
+              }
+            },
+            "required": [
+              "traits",
+              "entity"
+            ]
+          }
+        }
+      }
+    },
     "entities": {
       "description": "The entities in the library, they key is used as the entity name.",
       "type": "object",

--- a/tests/resources/library_apiComplianceSuite.json
+++ b/tests/resources/library_apiComplianceSuite.json
@@ -23,6 +23,63 @@
       "default": {}
     }
   },
+  "defaultEntities": {
+    "read": [
+      {
+        "traits": [
+          "b",
+          "c"
+        ],
+        "entity": "a_default_read_entity_for_b_and_c"
+      },
+      {
+        "traits": [
+          "a",
+          "b"
+        ],
+        "entity": "a_default_read_entity_for_a_and_b"
+      },
+      {
+        "traits": [
+          "c",
+          "d"
+        ],
+        "entity": null
+      }
+    ],
+    "write": [
+      {
+        "traits": [
+          "b",
+          "c"
+        ],
+        "entity": "a_default_write_entity_for_b_and_c"
+      },
+      {
+        "traits": [
+          "a",
+          "b"
+        ],
+        "entity": "a_default_write_entity_for_a_and_b"
+      }
+    ],
+    "createRelated": [
+      {
+        "traits": [
+          "b",
+          "c"
+        ],
+        "entity": "a_default_relatable_entity_for_b_and_c"
+      },
+      {
+        "traits": [
+          "a",
+          "b"
+        ],
+        "entity": "a_default_relatable_entity_for_a_and_b"
+      }
+    ]
+  },
   "entities": {
     "anAsset⭐︎": {
       "versions": [


### PR DESCRIPTION
Closes #53. Add support for the `defaultEntityReference` API method, which provides a way for hosts to get a "starting point" for further queries.

Add a new top-level dictionary to the JSON database `defaultEntities`, which has a mapping per access mode of trait set to entity reference.

If no matching trait set is found in the JSON database, then respond with `kInvalidTraitSet`. In real-world managers, an unrecognised trait set would probably elicit a response of `None` (for "no appropriate default"), rather than exception. But here we make a `None` response explicit by specifying `null` in the JSON database.