### PR TITLE
Add relationship access and version overrides

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,10 @@ v1.0.0-beta.x.y
   value presenting BAL's in-memory library as serialised JSON.
   [#51](https://github.com/OpenAssetIO/OpenAssetIO-Manager-BAL/issues/51)
 
+- Added support for access mode specific relationships and overriding
+  the special-case version relationship in the JSON database. Querying a
+  relationship with a non-`kRead` access mode is no longer an error.
+  [KatanaOpenAssetIO#4](https://github.com/TheFoundryVisionmongers/KatanaOpenAssetIO/pull/4)
 
 v1.0.0-beta.1.0
 ---------------

--- a/plugin/openassetio_manager_bal/bal.py
+++ b/plugin/openassetio_manager_bal/bal.py
@@ -71,6 +71,7 @@ class Relation:
 
     traits: Dict[str, Dict]
     entity_infos: List[EntityInfo]
+    access: str
 
 
 def load_library(path: str) -> dict:
@@ -147,6 +148,7 @@ def entity(entity_info: EntityInfo, library: dict) -> Entity:
                 EntityInfo(name, version=None, access=entity_info.access)
                 for name in relation["entities"]
             ],
+            access=relation.get("access", "read"),
         )
         for relation in entity_dict.get("relations", [])
     ]
@@ -223,6 +225,8 @@ def related_references(
     entity_data = entity(entity_info, library)
 
     for relation in entity_data.relations:
+        if not relation.access == entity_info.access:
+            continue
         # Check if this relation contains the requested traits
         if not _dict_has_traits(relation.traits, requested_relation_traits):
             continue

--- a/schema.json
+++ b/schema.json
@@ -502,6 +502,9 @@
                 "type": "object",
                 "description": "The definition of a particular relationship",
                 "properties": {
+                  "access": {
+                    "description": "Access mode that this relationship applies to (default is 'read')"
+                  },
                   "traits": {
                     "description": "Traits and their associated properties that describe the nature of the relationship itself (not the related entities).",
                     "type": "object",

--- a/tests/resources/library_apiComplianceSuite.json
+++ b/tests/resources/library_apiComplianceSuite.json
@@ -181,6 +181,19 @@
         {
           "traits": {"missing": {}},
           "entities": ["missingEntity"]
+        },
+        {
+          "access": "write",
+          "traits": {"publishable": {}},
+          "entities": ["anAsset⭐︎"]
+        },
+        {
+          "traits": {
+            "openassetio-mediacreation:lifecycle.Version": {},
+            "openassetio-mediacreation:relationship.Unbounded": {},
+            "openassetio-mediacreation:usage.Relationship": {}
+          },
+          "entities": ["another 𝓐𝓼𝓼𝓼𝓮𝔱"]
         }
       ]
     },


### PR DESCRIPTION
Part of testing TheFoundryVisionmongers/KatanaOpenAssetIO#4.

BAL would error when performing relationship queries with a non-`kRead` access mode. However, such queries are valid for publishing workflows and so must be supported in order to test host applications.

So add an optional `"access"` flag that can be added to relationship definitions in the JSON database, overriding the default `kRead` access, and limiting that relationship to the specific access mode.

Hence no longer error when responding to relationship queries for non-`kRead` access modes (the default response instead being an empty set of entity references).

Additionally, if a version relationship trait set is specified in the JSON database, then prefer that over the built-in versioning behaviour. A long term goal would be to remove the built-in versioning behaviour in favour of leveraging generic relationship queries (#88). This at least gets us part way there to support some use cases.